### PR TITLE
feat: adds script to update dependabot config

### DIFF
--- a/hokusai-app-updater/update_scripts/update_dependabot.sh
+++ b/hokusai-app-updater/update_scripts/update_dependabot.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+MATCH=<match-pattern>
+REPLACE=<replace-pattern>
+
+echo "replacing '$MATCH' with '$REPLACE' in dependabot.yml"
+
+sed -i "s|$MATCH|$REPLACE|" .github/dependabot.yml


### PR DESCRIPTION
Add a script to be used with `update-apps.sh` when making dependabot config updates across many repos.
