### PR TITLE
chore: use dedicated vars for letsencrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # opstools
 
 Tools for Operations.
+
+# setup
+
+Read/run the script:
+
+`./bin/setup`
+
+Load environment vars:
+
+`set -a; source .env.shared; set +a;`

--- a/letsencrypt-request-cert/README.md
+++ b/letsencrypt-request-cert/README.md
@@ -15,7 +15,7 @@ Convenience script to:
 Here's a sample run requesting certs for `*.example.com`/`*.prd.example.com`/`*.stg.example.com`:
 
 ```
-userX$ DOMAIN=example.com S3_BUCKET=example-bucket ./cert.sh
+userX$ ./cert.sh
 Requesting certs for domains: *.example.com,*.prd.example.com,*.stg.example.com
 They will be saved in: s3://example-bucket/certificates/example.com/
 Creating certbot dirs under your home dir...

--- a/letsencrypt-request-cert/cert.sh
+++ b/letsencrypt-request-cert/cert.sh
@@ -8,26 +8,27 @@ function usage() {
 
     Please ensure these vars are set in env:
 
-      DOMAIN - The domain to request certs for.
+      CERT_DOMAIN - The domain to request certs for.
                For example, if domain is foo.bar, certs will be requested for:
                *.foo.bar, *.prd.foo.bar, *.stg.foo.bar
 
-      S3_BUCKET - Name of the S3 bucket to save the certs in.
+      CERT_S3_BUCKET - Name of the S3 bucket to save the certs in.
                   For example, if domain is foo.bar, and S3 bucket is 'foobar-data', the certs will be saved in:
                   s3://foobar-data/certificates/foo.bar/"
 
+    Did you run setup and load the env vars? See project README.md for more info.
 EOF
 }
 
 # make sure vars are set in the env
-if [[ "$DOMAIN" == '' ]] || [[ "$S3_BUCKET" == '' ]]
+if [[ "$CERT_DOMAIN" == '' ]] || [[ "$CERT_S3_BUCKET" == '' ]]
 then
   usage
   exit 1
 fi
 
-S3_LOCATION="s3://$S3_BUCKET/certificates/$DOMAIN/"
-CERT_DOMAINS="*.$DOMAIN,*.prd.$DOMAIN,*.stg.$DOMAIN"
+S3_LOCATION="s3://$CERT_S3_BUCKET/certificates/$CERT_DOMAIN/"
+CERT_DOMAINS="*.$CERT_DOMAIN,*.prd.$CERT_DOMAIN,*.stg.$CERT_DOMAIN"
 
 echo "Requesting certs for domains: $CERT_DOMAINS"
 echo "They will be saved in: $S3_LOCATION"
@@ -36,7 +37,7 @@ echo "Creating certbot dirs under your home dir..."
 CERTBOT_DIR=~/certbot
 CERTBOT_ETC_DIR=~/certbot/etc
 CERTBOT_VAR_DIR=~/certbot/lib
-CERTBOT_CERT_DIR="~/certbot/etc/live/$DOMAIN"
+CERTBOT_CERT_DIR="~/certbot/etc/live/$CERT_DOMAIN"
 mkdir -p "$CERTBOT_ETC_DIR"
 mkdir -p "$CERTBOT_VAR_DIR"
 
@@ -46,11 +47,11 @@ Running certbot, follow interactive prompts. See README for how to answer prompt
 When prompted, provide to certbot these domains: $CERT_DOMAINS
 To prove that you own those domains, certbot will ask you to create the following TXT records:
 
-_acme-challenge.$DOMAIN
-_acme-challenge.prd.$DOMAIN
-_acme-challenge.stg.$DOMAIN
+_acme-challenge.$CERT_DOMAIN
+_acme-challenge.prd.$CERT_DOMAIN
+_acme-challenge.stg.$CERT_DOMAIN
 
-Go to Route53, create them all under '$DOMAIN' hosted zone. (not under prd/stg.$DOMAIN zones)
+Go to Route53, create them all under '$CERT_DOMAIN' hosted zone. (not under prd/stg.$CERT_DOMAIN zones)
 
 After you create each record, verify it exists using dig/nslookup. (make sure you are not on VPN otherwise you won't see the record)
 
@@ -80,9 +81,9 @@ echo "Ship the tar up to $S3_LOCATION which currently has:"
 aws s3 ls "$S3_LOCATION" || echo "Something wrong with executing AWS CLI."
 aws s3 cp "$TAR_FILE" "$S3_LOCATION"
 
-K8S_SECRET_NAME=$(echo $DOMAIN | sed 's/\./-/g')-tls
-CERT_DIR="$CERTBOT_ETC_DIR/archive/$DOMAIN/fullchain1.pem"
-KEY_DIR="$CERTBOT_ETC_DIR/archive/$DOMAIN/privkey1.pem"
+K8S_SECRET_NAME=$(echo $CERT_DOMAIN | sed 's/\./-/g')-tls
+CERT_DIR="$CERTBOT_ETC_DIR/archive/$CERT_DOMAIN/fullchain1.pem"
+KEY_DIR="$CERTBOT_ETC_DIR/archive/$CERT_DOMAIN/privkey1.pem"
 
 echo "Loading new cert/key into staging k8s for use by ingress controllers..."
 kubectl --context staging delete secret "$K8S_SECRET_NAME"
@@ -90,7 +91,7 @@ kubectl --context staging create secret tls "$K8S_SECRET_NAME" \
   --cert="$CERT_DIR" \
   --key="$KEY_DIR"
 
-echo "Go visit https://kubernetes.stg.$DOMAIN and check out the cert."
+echo "Go visit https://kubernetes.stg.$CERT_DOMAIN and check out the cert."
 read -p "Hit enter if the cert is good."
 read -p "You said cert is good. I am ready to repeat for prod k8s. Hit enter to proceed."
 
@@ -100,7 +101,7 @@ kubectl --context production create secret tls "$K8S_SECRET_NAME" \
   --cert="$CERT_DIR" \
   --key="$KEY_DIR"
 
-echo "Go visit https://kubernetes.prd.$DOMAIN and check out the cert."
+echo "Go visit https://kubernetes.prd.$CERT_DOMAIN and check out the cert."
 
 echo "Deleting certbot files from your home dir..."
 rm -rf ~/certbot


### PR DESCRIPTION
https://artsyproduct.atlassian.net/browse/PLATFORM-4155

This makes a couple of adjustments to the letsencrypt renewal process as it pertains to execution of the `cert.sh` script.

* switch to using dedicated vars for the letsencrypt script
* update script and docs to reflect this change
* update `.env.shared` to hold new keys: `CERT_DOMAIN`, `CERT_S3_BUCKET`

If this is approved I will upload the new `.env.shared`.