### PR TITLE
fix: extraneous words in terraform drift detection output.

### DIFF
--- a/src/terraform_drift_detection/detect.py
+++ b/src/terraform_drift_detection/detect.py
@@ -8,5 +8,5 @@ from terraform_drift_detection.util import Drift
 
 init()
 if Drift.DRIFT in check_repos():
-  logging.error('Drift detected. Please see logs.')
+  logging.error('Drift detected.')
   exit(1)


### PR DESCRIPTION
There's no need to say `Please see logs`, because the user is already looking at the logs when seeing this message.