### PR TITLE
feat: let terraform drift detection cronjob be env scoped [#future-friday]

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,9 +127,9 @@
         "filename": "src/terraform_drift_detection/test/test_terraform.py",
         "hashed_secret": "aa891d4e101044bdd59c2b7ce36a2eb8f3b16793",
         "is_verified": false,
-        "line_number": 53
+        "line_number": 32
       }
     ]
   },
-  "generated_at": "2023-02-05T02:53:00Z"
+  "generated_at": "2023-02-11T01:18:56Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -127,9 +127,9 @@
         "filename": "src/terraform_drift_detection/test/test_terraform.py",
         "hashed_secret": "aa891d4e101044bdd59c2b7ce36a2eb8f3b16793",
         "is_verified": false,
-        "line_number": 32
+        "line_number": 34
       }
     ]
   },
-  "generated_at": "2023-02-11T01:18:56Z"
+  "generated_at": "2023-02-11T03:06:49Z"
 }

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,0 +1,34 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opstools-terraform-drift-detection
+spec:
+  schedule: "05 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+        spec:
+          containers:
+            - name: opstools-terraform-drift-detection
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
+              command: ["src/terraform_drift_detection/detect.py"]
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: opstools-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background

--- a/src/terraform_drift_detection/terraform_drift_detection/config.py
+++ b/src/terraform_drift_detection/terraform_drift_detection/config.py
@@ -6,27 +6,46 @@ class AppConfig:
   ''' get env config and validate them '''
   def __init__(self, env):
     self.github_token = env.get('GITHUB_TOKEN', '')
-    repo_names = env.get('REPO_NAMES', '')
-    self.repos = repo_names.split(',')
+    reposdirs = env.get('REPOSDIRS', '')
+    self.repos_dirs = parse_reposdirs(reposdirs)
 
-    if not validate(self.github_token, repo_names, self.repos):
+    if not validate(self.github_token, reposdirs, self.repos_dirs):
       raise AppConfigError('Error: Env vars are missing or invalid.')
 
 class AppConfigError(Exception):
   pass
 
-def validate(github_token, repo_names, repos):
+def parse_reposdirs(reposdirs):
+  ''' given 'repo1:dir1,repo1:dir2,repo2:dir1', return {'repo1': ['dir1', 'dir2'], 'repo2': ['dir1']} '''
+  repos_dirs = {}
+  for repodir in reposdirs.split(','):
+    repo, dir = repodir.split(':')
+    repos_dirs[repo] = repos_dirs.get(repo, []) + [dir]
+  return repos_dirs
+
+def validate(github_token, reposdirs, repos_dirs):
   ''' validate input data '''
   validator = Validator()
   schema = {
     'github_token': {'type': 'string', 'empty': False},
-    'repo_names': {'type': 'string', 'empty': False},
-    'repos': {'type': 'list', 'empty': False, 'schema': {'type': 'string', 'empty': False}}
+    'reposdirs': {'type': 'string', 'empty': False},
+    'repos_dirs': {
+      'type': 'dict',
+      'empty': False,
+      'keysrules': {'type': 'string', 'empty': False},
+      'valuesrules': {
+        'type': 'list',
+        'empty': False,
+        'schema': {
+          'type': 'string', 'empty': False
+        }
+      }
+    }
   }
   document = {
     'github_token': github_token,
-    'repo_names': repo_names,
-    'repos': repos
+    'reposdirs': reposdirs,
+    'repos_dirs': repos_dirs
   }
   return validator.validate(document, schema)
 

--- a/src/terraform_drift_detection/terraform_drift_detection/terraform.py
+++ b/src/terraform_drift_detection/terraform_drift_detection/terraform.py
@@ -43,6 +43,7 @@ def check_tf_dir(tf_dir):
   if output.returncode == 0:
     return Drift.NODRIFT
   elif output.returncode == 2:
+    log_the_drift(output.stdout)
     return Drift.DRIFT
   else:
     return Drift.UNKNOWN
@@ -56,3 +57,10 @@ def find_tf_dirs(dirx):
   ]
   tf_dirs = [os.path.dirname(path) for path in tf_files]
   return sorted(list(set(tf_dirs)))
+
+def log_the_drift(tf_output):
+  ''' log resources mentioned in terraform plan output showing changes '''
+  # the lines marked with '#', example:
+  # '# aws_instance.serverx will be updated in-place'
+  for line in tf_output.split('\n'):
+    if '# ' in line: logging.info(line)

--- a/src/terraform_drift_detection/test/__init__.py
+++ b/src/terraform_drift_detection/test/__init__.py
@@ -2,5 +2,5 @@ import os
 
 # initialize environment for tests
 
-os.environ['REPO_NAMES'] = 'foorepo'
+os.environ['REPOSDIRS'] = 'foorepo:foodir'
 os.environ['GITHUB_TOKEN'] = 'footoken'

--- a/src/terraform_drift_detection/test/fixtures/terraform.py
+++ b/src/terraform_drift_detection/test/fixtures/terraform.py
@@ -1,6 +1,11 @@
 import pytest
 
 from subprocess import CompletedProcess
+from terraform_drift_detection.util import Drift
+
+@pytest.fixture
+def expected_results():
+  return  [Drift.NODRIFT, Drift.NODRIFT, Drift.DRIFT, Drift.NODRIFT, Drift.DRIFT, Drift.UNKNOWN]
 
 @pytest.fixture
 def mock_clone_failed():
@@ -28,6 +33,14 @@ def mock_init_failed():
     }
     return return_values[cmd]
   return mock_run_cmd
+
+@pytest.fixture
+def mock_multiple_repo_dir_results():
+  return [
+    [Drift.NODRIFT],
+    [Drift.NODRIFT, Drift.DRIFT],
+    [Drift.NODRIFT, Drift.DRIFT, Drift.UNKNOWN],
+  ]
 
 @pytest.fixture
 def mock_plan_drift():

--- a/src/terraform_drift_detection/test/test_config.py
+++ b/src/terraform_drift_detection/test/test_config.py
@@ -1,27 +1,40 @@
 import pytest
 
-from terraform_drift_detection.config import AppConfig, AppConfigError, config, validate
+from terraform_drift_detection.config import AppConfig, AppConfigError, config, parse_reposdirs, validate
 
 def describe_AppConfig():
-  def it_raises_on_bad_env():
-    with pytest.raises(AppConfigError):
+  def it_raises_value_error():
+    with pytest.raises(ValueError):
       AppConfig({})
-  def it_is_happy_on_good_env():
-      AppConfig({'REPO_NAMES': 'foorepo', 'GITHUB_TOKEN': 'footoken'})
+  def it_raises_appconfig_error():
+    with pytest.raises(AppConfigError):
+      AppConfig({'REPOSDIRS': 'foorepo:foodir', 'GITHUB_TOKEN': ''})
+  def it_passes_on_good_env():
+      AppConfig({'REPOSDIRS': 'foorepo:foodir', 'GITHUB_TOKEN': 'footoken'})
 
 def describe_config():
   def it_is_initialized():
-    assert config.repos == ['foorepo']
+    assert config.repos_dirs == {'foorepo': ['foodir']}
     assert config.github_token == 'footoken'
+
+def describe_parse_reposdirs():
+  def it_parses():
+    reposdirs = 'repo1:dir1,repo1:dir2,repo2:dir1'
+    assert parse_reposdirs(reposdirs) == {
+      'repo1': ['dir1', 'dir2'],
+      'repo2': ['dir1']
+    }
 
 def describe_validate():
   def it_returns_true_for_good_values():
-    assert validate('footoken', 'foorepo', ['foorepo']) == True
+    assert validate('footoken', 'foorepo:foodir', {'foorepo': ['foodir']}) == True
   def it_returns_false_for_empty_token():
-    assert validate('', 'foorepo', ['foorepo']) == False
-  def it_returns_false_for_empty_repo_names():
-    assert validate('footoken', '', ['foorepo']) == False
-  def it_returns_false_for_empty_repo_list():
-    assert validate('footoken', 'foorepo', []) == False
-  def it_returns_false_for_repo_list_with_empty_strings():
-    assert validate('footoken', 'foorepo', ['foorepo', '']) == False
+    assert validate('', 'foorepo:foodir', {'foorepo': ['foodir']}) == False
+  def it_returns_false_for_empty_reposdirs():
+    assert validate('footoken', '', {'foorepo': ['foodir']}) == False
+  def it_returns_false_for_empty_repos_dirs_dict():
+    assert validate('footoken', 'foorepo:foodir', {}) == False
+  def it_returns_false_for_repos_dirs_with_empty_dir_list():
+    assert validate('footoken', 'foorepo:foodir', {'foorepo': []}) == False
+  def it_returns_false_for_repos_dirs_with_blank_dir():
+    assert validate('footoken', 'foorepo:foodir', {'foorepo': ['foodir', '']}) == False

--- a/src/terraform_drift_detection/test/test_terraform.py
+++ b/src/terraform_drift_detection/test/test_terraform.py
@@ -4,78 +4,88 @@ import terraform_drift_detection.terraform
 
 from functools import reduce
 from terraform_drift_detection.config import config
-from terraform_drift_detection.terraform import check_dir, check_repo, check_repos, find_tf_dirs
+from terraform_drift_detection.terraform import check_dir, check_repo, check_repos, check_tf_dir, find_tf_dirs
 from terraform_drift_detection.util import Drift
 from test.fixtures.terraform import \
+  expected_results, \
   mock_clone_failed, \
   mock_clone_success, \
   mock_init_failed, \
+  mock_multiple_repo_dir_results, \
   mock_plan_drift, \
   mock_plan_no_drift, \
   mock_plan_unknown
 
 def describe_check_dir():
+  def it_returns_correct_check_tf_dir_results(mocker):
+    mocker.patch('terraform_drift_detection.terraform.find_tf_dirs', return_value=['dir1', 'dir2', 'dir3'])
+    mocker.patch('terraform_drift_detection.terraform.check_tf_dir').side_effect = [Drift.NODRIFT, Drift.DRIFT, Drift.UNKNOWN]
+    results = check_dir('foodir')
+    assert results == [Drift.NODRIFT, Drift.DRIFT, Drift.UNKNOWN]
+
+def describe_check_repo():
+  def it_returns_unknown_if_clone_failed(mocker, mock_clone_failed):
+    mocker.patch('terraform_drift_detection.terraform.run_cmd').side_effect = mock_clone_failed
+    spy = mocker.spy(terraform_drift_detection.terraform, 'run_cmd')
+    results = check_repo('foorepo', 'foobasedir')
+    assert spy.call_count == 1
+    spy.assert_has_calls([mocker.call('git clone https://github:footoken@github.com/artsy/foorepo.git', 'foobasedir')])
+    assert results == [Drift.UNKNOWN]
+  def it_returns_correct_check_dir_results(expected_results, mocker, mock_clone_success, mock_multiple_repo_dir_results):
+    mocker.patch('terraform_drift_detection.terraform.run_cmd').side_effect = mock_clone_success
+    mocker.patch('terraform_drift_detection.terraform.check_dir').side_effect = mock_multiple_repo_dir_results
+    mocker.patch.object(config, 'repos_dirs', {'foorepo': ['dir1', 'dir2', 'dir3']})
+    run_cmd_spy = mocker.spy(terraform_drift_detection.terraform, 'run_cmd')
+    check_dir_spy = mocker.spy(terraform_drift_detection.terraform, 'check_dir')
+    results = check_repo('foorepo', 'foobasedir')
+    assert run_cmd_spy.call_count == 1
+    assert check_dir_spy.call_count == 3
+    run_cmd_spy.assert_has_calls([mocker.call('git clone https://github:footoken@github.com/artsy/foorepo.git', 'foobasedir')])
+    check_dir_spy.assert_has_calls(
+      [
+        mocker.call('foobasedir/foorepo/dir1'),
+        mocker.call('foobasedir/foorepo/dir2'),
+        mocker.call('foobasedir/foorepo/dir3')
+      ]
+    )
+    assert results == expected_results
+
+def describe_check_repos():
+  def it_returns_correct_check_repo_results(expected_results, mocker, mock_multiple_repo_dir_results):
+    mocker.patch('terraform_drift_detection.terraform.check_repo').side_effect = mock_multiple_repo_dir_results
+    mocker.patch.object(config, 'repos_dirs', {'repo1': ['dir1'], 'repo2':['dir2'], 'repo3':['dir3']})
+    results = check_repos()
+    assert results == expected_results
+
+def describe_check_tf_dir():
   def it_returns_unknown_if_init_failed(mocker, mock_init_failed):
     mocker.patch('terraform_drift_detection.terraform.run_cmd').side_effect = mock_init_failed
     spy = mocker.spy(terraform_drift_detection.terraform, 'run_cmd')
-    result = check_dir('foodir')
+    result = check_tf_dir('foodir')
     assert spy.call_count == 1
     spy.assert_has_calls([mocker.call('terraform init', 'foodir')])
     assert result == Drift.UNKNOWN
   def it_returns_no_drift_if_plan_returned_zero(mocker, mock_plan_no_drift):
     mocker.patch('terraform_drift_detection.terraform.run_cmd').side_effect = mock_plan_no_drift
     spy = mocker.spy(terraform_drift_detection.terraform, 'run_cmd')
-    result = check_dir('foodir')
+    result = check_tf_dir('foodir')
     assert spy.call_count == 2
     spy.assert_has_calls([mocker.call('terraform init', 'foodir'), mocker.call('terraform plan -detailed-exitcode', 'foodir')])
     assert result == Drift.NODRIFT
   def it_returns_drift_if_plan_returned_two(mocker, mock_plan_drift):
     mocker.patch('terraform_drift_detection.terraform.run_cmd').side_effect = mock_plan_drift
     spy = mocker.spy(terraform_drift_detection.terraform, 'run_cmd')
-    result = check_dir('foodir')
+    result = check_tf_dir('foodir')
     assert spy.call_count == 2
     spy.assert_has_calls([mocker.call('terraform init', 'foodir'), mocker.call('terraform plan -detailed-exitcode', 'foodir')])
     assert result == Drift.DRIFT
   def it_returns_unknown_if_plan_returned_something_else(mocker, mock_plan_unknown):
     mocker.patch('terraform_drift_detection.terraform.run_cmd').side_effect = mock_plan_unknown
     spy = mocker.spy(terraform_drift_detection.terraform, 'run_cmd')
-    result = check_dir('foodir')
+    result = check_tf_dir('foodir')
     assert spy.call_count == 2
     spy.assert_has_calls([mocker.call('terraform init', 'foodir'), mocker.call('terraform plan -detailed-exitcode', 'foodir')])
     assert result == Drift.UNKNOWN
-
-def describe_check_repo():
-  def it_returns_unknown_if_clone_failed(mocker, mock_clone_failed):
-    mocker.patch('terraform_drift_detection.terraform.run_cmd').side_effect = mock_clone_failed
-    spy = mocker.spy(terraform_drift_detection.terraform, 'run_cmd')
-    results = check_repo('foorepo', 'foodir')
-    assert spy.call_count == 1
-    spy.assert_has_calls([mocker.call('git clone https://github:footoken@github.com/artsy/foorepo.git', 'foodir')])
-    assert results == [Drift.UNKNOWN]
-  def it_returns_correct_check_dir_results(mocker, mock_clone_success):
-    mocker.patch('terraform_drift_detection.terraform.run_cmd').side_effect = mock_clone_success
-    mocker.patch('terraform_drift_detection.terraform.find_tf_dirs', return_value=['dir1', 'dir2', 'dir3'])
-    mocker.patch('terraform_drift_detection.terraform.check_dir').side_effect = [Drift.NODRIFT, Drift.DRIFT, Drift.UNKNOWN]
-    run_cmd_spy = mocker.spy(terraform_drift_detection.terraform, 'run_cmd')
-    check_dir_spy = mocker.spy(terraform_drift_detection.terraform, 'check_dir')
-    result = check_repo('foorepo', 'foodir')
-    assert run_cmd_spy.call_count == 1
-    assert check_dir_spy.call_count == 3
-    run_cmd_spy.assert_has_calls([mocker.call('git clone https://github:footoken@github.com/artsy/foorepo.git', 'foodir')])
-    check_dir_spy.assert_has_calls([mocker.call('dir1'), mocker.call('dir2'), mocker.call('dir3')])
-    assert result == [Drift.NODRIFT, Drift.DRIFT, Drift.UNKNOWN]
-
-def describe_check_repos():
-  def it_returns_correct_check_repo_results(mocker):
-    all_results = [
-      [Drift.NODRIFT],
-      [Drift.NODRIFT, Drift.DRIFT],
-      [Drift.NODRIFT, Drift.DRIFT, Drift.UNKNOWN],
-    ]
-    mocker.patch('terraform_drift_detection.terraform.check_repo').side_effect = all_results
-    mocker.patch.object(config, 'repos', ['foo', 'bar', 'baz'])
-    results = check_repos()
-    assert results == reduce(lambda x, y: x + y, all_results)
 
 def describe_find_tf_dirs():
   def it_finds(mocker):


### PR DESCRIPTION
[PLATFORM-4945]

Adding two features to Terraform Drift Detection:

- Add a Prod k8s cronjob which will cover Prod terraform resources and those that are used in both environments (a.k.a. `shared`). The existing Staging k8s cronjob will be narrowed to cover Staging resources only. The mapping of cronjob to resources will be configured via Env. `REPO_NAMES` Env var will be replaced by `REPOSDIRS` which specifies the Github repos/folders for the cronjob, in this format:
  ```
  REPOSDIRS=repo1:dir1,repo1:dir2,repo2:dir1,...
  ```
  We assume that prod, shared, and staging terraform resources are housed in their respective folders. The new var has been added to Env (both Prod and Staging). The old var is still in Staging Env since the existing cronjob relies on it.

- When `terraform plan` reports changes, log the resources that those changes are reported on. The details are omitted.

Follow-up steps after merging PR:
---

- [ ] Delete `REPO_NAMES` (the old var) from Staging Env. (Prod Env does not have this var, so nothing to do there.)
- [ ] Update the [Jobs monitors](https://app.datadoghq.com/monitors/manage?q=jobs). Exclude these cronjobs from the existing monitors. Create two new monitors and limit them to these cronjobs. Let new monitors alert to Velocity channel.

[PLATFORM-4945]: https://artsyproduct.atlassian.net/browse/PLATFORM-4945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ