### PR TITLE
feat: add cronjobs for creating and pruning k8s backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN pip --no-cache-dir install poetry
 RUN pip --no-cache-dir install awscli --upgrade
 
 ARG terraform_version=0.12.31
+ARG kubectl_version=1.19.16
 
 RUN apk --no-cache --quiet add \
   curl \
@@ -18,6 +19,10 @@ RUN curl https://releases.hashicorp.com/terraform/${terraform_version}/terraform
   && unzip -d /tmp /tmp/terraform_${terraform_version}_linux_amd64.zip \
   && chmod +x /tmp/terraform \
   && mv /tmp/terraform /usr/local/bin/terraform
+
+RUN curl https://storage.googleapis.com/kubernetes-release/release/v${kubectl_version}/bin/linux/amd64/kubectl -o /tmp/kubectl \
+  && chmod 755 /tmp/kubectl \
+  && mv /tmp/kubectl /usr/local/bin/kubectl
 
 WORKDIR /src
 

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,4 +1,40 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opstools
+  namespace: default
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: opstools
+  namespace: default
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: opstools
+  namespace: default
+subjects:
+- kind: User
+  name: system:serviceaccount:default:opstools
+roleRef:
+  kind: Role
+  name: opstools
+  apiGroup: rbac.authorization.k8s.io
+
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -18,6 +54,77 @@ spec:
             - name: opstools-terraform-drift-detection
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
               command: ["src/terraform_drift_detection/detect.py"]
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: opstools-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opstools-k8s-create-backup
+spec:
+  schedule: "40 8 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+        spec:
+          containers:
+            - name: opstools-k8s-create-backup
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
+              command: ["src/kubernetes_backup/backup.py", "--s3"]
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: opstools-environment
+          serviceAccountName: opstools
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opstools-k8s-prune-backup
+spec:
+  schedule: "40 9 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+        spec:
+          containers:
+            - name: opstools-k8s-prune-backup
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
+              command: ["src/kubernetes_backup/prune.py", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -1,4 +1,40 @@
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: opstools
+  namespace: default
+
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: opstools
+  namespace: default
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: opstools
+  namespace: default
+subjects:
+- kind: User
+  name: system:serviceaccount:default:opstools
+roleRef:
+  kind: Role
+  name: opstools
+  apiGroup: rbac.authorization.k8s.io
+
+---
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -18,6 +54,77 @@ spec:
             - name: opstools-terraform-drift-detection
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
               command: ["src/terraform_drift_detection/detect.py"]
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: opstools-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opstools-k8s-create-backup
+spec:
+  schedule: "20 8 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+        spec:
+          containers:
+            - name: opstools-k8s-create-backup
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
+              command: ["src/kubernetes_backup/backup.py", "--s3"]
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: opstools-environment
+          serviceAccountName: opstools
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opstools-k8s-prune-backup
+spec:
+  schedule: "20 9 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+        spec:
+          containers:
+            - name: opstools-k8s-prune-backup
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
+              command: ["src/kubernetes_backup/prune.py", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:


### PR DESCRIPTION
[PLATFORM-5007]

- Add CronJobs for creating/pruning k8s backups. The CronJobs replace [the Jenkins job](https://joe.artsy.net/job/substance-backups/).
- Add `kubectl` to docker image for use by the create backup job.
- Add a k8s service account and associated permissions. The SA is used by the create backup job. k8s will mount that SA's token into the pod, and `kubectl` will use it. No `kubeconfig` required.

Necessary vars have been created in opstool's k8s environment.

When merging PR, please disable the Jenkins job.

Related PR: https://github.com/artsy/infrastructure/pull/476



[PLATFORM-5007]: https://artsyproduct.atlassian.net/browse/PLATFORM-5007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ