### PR TITLE
fix: rabbitmq backup script references bash

### DIFF
--- a/src/rabbitmq/backup_broker_definitions.sh
+++ b/src/rabbitmq/backup_broker_definitions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env sh
 
 set -e
 


### PR DESCRIPTION
[Job fails](https://joe.artsy.net/job/rabbitmq-production-broker-definition-backup/715/) because Docker image does not have Bash.

Switch script to `sh`.