### PR TITLE
feat: check ECR repos for terraforming

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,4 @@ test:
 	pytest src/kubernetes_cleanup_jobs
 	pytest src/lib
 	pytest src/terraform_drift_detection
+	pytest src/ecr_check_repos_for_terraform

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,3 @@ test:
 	pytest src/kubernetes_cleanup_jobs
 	pytest src/lib
 	pytest src/terraform_drift_detection
-	pytest src/ecr_check_repos_for_terraform

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -211,3 +211,39 @@ spec:
                     operator: In
                     values:
                     - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opstools-ecr-check-repos-for-terraform
+spec:
+  schedule: "13 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+        spec:
+          containers:
+            - name: opstools-ecr-check-repos-for-terraform
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
+              command: ["src/ecr_check_repos_for_terraform/check.py"]
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: opstools-environment
+          serviceAccountName: opstools
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background

--- a/src/ecr_check_repos_for_terraform/check.py
+++ b/src/ecr_check_repos_for_terraform/check.py
@@ -15,5 +15,6 @@ if __name__ == "__main__":
   repos = check()
   if len(repos) > 0:
     logging.info(f"Repositories found: {repos}")
+    exit(1)
   else:
     logging.info("None found.")

--- a/src/ecr_check_repos_for_terraform/check.py
+++ b/src/ecr_check_repos_for_terraform/check.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python
+
+import logging
+
+# initialize the app
+from ecr_check_repos_for_terraform.config import config
+
+from ecr_check_repos_for_terraform.check_repos import (
+  check
+)
+
+if __name__ == "__main__":
+
+  logging.info('Checking ECR for repositories that are not managed by Terraform and are not for testing.')
+  repos = check()
+  if len(repos) > 0:
+    logging.info(f"Found ECR repos that are non-terraform-managed and not-for-testing: {repos}")

--- a/src/ecr_check_repos_for_terraform/check.py
+++ b/src/ecr_check_repos_for_terraform/check.py
@@ -5,13 +5,15 @@ import logging
 # initialize the app
 from ecr_check_repos_for_terraform.config import config
 
-from ecr_check_repos_for_terraform.check_repos import (
-  check
-)
+from ecr_check_repos_for_terraform.check_repos import check
 
 if __name__ == "__main__":
 
-  logging.info('Checking ECR for repositories that are not managed by Terraform and are not for testing.')
+  logging.info(
+    'Checking ECR for repositories that perhaps should be added to Terraform...'
+  )
   repos = check()
   if len(repos) > 0:
-    logging.info(f"Found ECR repos that are non-terraform-managed and not-for-testing: {repos}")
+    logging.info(f"Repositories found: {repos}")
+  else:
+    logging.info("None found.")

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/check_repos.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/check_repos.py
@@ -21,11 +21,8 @@ def check():
   tag = {'Key': 'env', 'Value': 'test'}
   test_repos = ecr_repos.repos_with_tag(tag)
 
-  non_terraform_managed_repos = list_subtract(
-    all_repos, terraform_managed_repos
+  return list_subtract(
+    all_repos,
+    terraform_managed_repos,
+    test_repos
   )
-  final_repos = list_subtract(
-    non_terraform_managed_repos, test_repos
-  )
-
-  return final_repos

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/check_repos.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/check_repos.py
@@ -1,0 +1,19 @@
+import logging
+
+import ecr_check_repos_for_terraform.context
+
+from lib.ecr import ECR
+from lib.ecr_repos import EcrRepos
+from lib.util import list_subtract
+
+def check():
+  ''' check for ecr repositories that should be managed by terraform '''
+  ecr_client = ECR()
+  repos_obj = EcrRepos(ecr_client)
+  all_repos = repos_obj.all_repos()
+  tag = {'Key': 'managed_by', 'Value': 'terraform'}
+  terraform_managed_repos = repos_obj.repos_with_tag(tag)
+  tag = {'Key': 'env', 'Value': 'test'}
+  test_repos = repos_obj.repos_with_tag(tag)
+  non_terraform_managed_repos = list_subtract(all_repos, terraform_managed_repos)
+  return list_subtract(non_terraform_managed_repos, test_repos)

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/config.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/config.py
@@ -13,10 +13,6 @@ class AppConfig:
       cmdline_args.loglevel
     )
 
-    context = env
-
-    self.context = context
-
     self._init_app(loglevel)
 
   def _init_app(self, loglevel):

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/config.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/config.py
@@ -1,0 +1,46 @@
+import os
+
+import argparse
+import logging
+
+import ecr_check_repos_for_terraform.context
+from lib.logging import setup_logging
+
+class AppConfig:
+  def __init__(self, cmdline_args, env):
+    ''' set app-wide configs and initialize the app '''
+    loglevel = (
+      cmdline_args.loglevel
+    )
+
+    context = env
+
+    self.context = context
+
+    self._init_app(loglevel)
+
+  def _init_app(self, loglevel):
+    ''' initialize the app '''
+    # initialize logging
+    setup_logging(eval('logging.' + loglevel))
+
+def parse_args():
+  ''' parse command line args '''
+  parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+  )
+  parser.add_argument(
+    '--loglevel',
+    choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+    default='INFO',
+    help='log level'
+  )
+  return parser.parse_args()
+
+def parse_env(env):
+  ''' parse and validate env vars '''
+  pass
+
+# import this from main script
+# object will be instantiated only once
+config = AppConfig(parse_args(), parse_env(os.environ))

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/context.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/context.py
@@ -1,0 +1,8 @@
+import sys
+
+from pathlib import Path
+
+# add repo root to sys.path
+# mostly for importing modules in 'lib' dir
+path_root = Path(__file__).parents[2]
+sys.path.append(str(path_root))

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/test/test_ecr.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/test/test_ecr.py
@@ -1,6 +1,0 @@
-import ecr_check_repos_for_terraform.check_repos
-
-from ecr_check_repos_for_terraform.check_repos import (
-  check
-)
-

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/test/test_ecr.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/test/test_ecr.py
@@ -1,0 +1,6 @@
+import ecr_check_repos_for_terraform.check_repos
+
+from ecr_check_repos_for_terraform.check_repos import (
+  check
+)
+

--- a/src/lib/ecr.py
+++ b/src/lib/ecr.py
@@ -1,0 +1,20 @@
+import boto3
+
+class ECR(object):
+  ''' interface with AWS ECR '''
+
+  def __init__(self):
+    self.ecr = boto3.client('ecr')
+
+  def get_repos(self):
+    repos = []
+    res = self.ecr.describe_repositories()
+    repos += res['repositories']
+    while 'nextToken' in res:
+      res = self.ecr.describe_repositories(nextToken=res['nextToken'])
+      repos += res['repositories']
+    return repos
+
+  def get_repo_tags(self, arn):
+    tags = self.ecr.list_tags_for_resource(resourceArn=arn)
+    return tags

--- a/src/lib/ecr_interface.py
+++ b/src/lib/ecr_interface.py
@@ -1,6 +1,6 @@
 import boto3
 
-class ECR(object):
+class ECRInterface(object):
   ''' interface with AWS ECR '''
 
   def __init__(self):

--- a/src/lib/ecr_interface.py
+++ b/src/lib/ecr_interface.py
@@ -1,10 +1,10 @@
-import boto3
+from boto3 import client as boto3client
 
 class ECRInterface(object):
   ''' interface with AWS ECR '''
 
   def __init__(self):
-    self._ecr = boto3.client('ecr')
+    self._ecr = boto3client('ecr')
 
   def get_repos(self):
     repos = []

--- a/src/lib/ecr_interface.py
+++ b/src/lib/ecr_interface.py
@@ -16,5 +16,4 @@ class ECRInterface(object):
     return repos
 
   def get_repo_tags(self, arn):
-    tags = self.ecr.list_tags_for_resource(resourceArn=arn)
-    return tags
+    return self.ecr.list_tags_for_resource(resourceArn=arn)

--- a/src/lib/ecr_interface.py
+++ b/src/lib/ecr_interface.py
@@ -11,9 +11,13 @@ class ECRInterface(object):
     res = self._ecr.describe_repositories()
     repos += res['repositories']
     while 'nextToken' in res:
-      res = self._ecr.describe_repositories(nextToken=res['nextToken'])
+      res = self._ecr.describe_repositories(
+        nextToken=res['nextToken']
+      )
       repos += res['repositories']
     return repos
 
   def get_repo_tags(self, arn):
-    return self._ecr.list_tags_for_resource(resourceArn=arn)
+    return self._ecr.list_tags_for_resource(
+      resourceArn=arn
+    )

--- a/src/lib/ecr_interface.py
+++ b/src/lib/ecr_interface.py
@@ -4,16 +4,16 @@ class ECRInterface(object):
   ''' interface with AWS ECR '''
 
   def __init__(self):
-    self.ecr = boto3.client('ecr')
+    self._ecr = boto3.client('ecr')
 
   def get_repos(self):
     repos = []
-    res = self.ecr.describe_repositories()
+    res = self._ecr.describe_repositories()
     repos += res['repositories']
     while 'nextToken' in res:
-      res = self.ecr.describe_repositories(nextToken=res['nextToken'])
+      res = self._ecr.describe_repositories(nextToken=res['nextToken'])
       repos += res['repositories']
     return repos
 
   def get_repo_tags(self, arn):
-    return self.ecr.list_tags_for_resource(resourceArn=arn)
+    return self._ecr.list_tags_for_resource(resourceArn=arn)

--- a/src/lib/ecr_repos.py
+++ b/src/lib/ecr_repos.py
@@ -1,0 +1,58 @@
+import logging
+
+class EcrRepo():
+  ''' manage 1 ECR repository's data '''
+  def __init__(self, repo_info, tags):
+    self.info = repo_info
+    self.name = repo_info['repositoryName']
+    self.arn = repo_info['repositoryArn']
+    self.tags = tags
+
+class EcrRepos():
+  ''' manage ECR repositories data '''
+  def __init__(self, ecr_client):
+    self._ecr_client = ecr_client
+    repos_info = ecr_client.get_repos()
+    self._repo_objs = []
+    for repo_info in repos_info:
+      repo_name = repo_info['repositoryName']
+      repo_arn = repo_info['repositoryArn']
+      res = ecr_client.get_repo_tags(repo_arn)
+      tags = res['tags']
+      repo_obj = EcrRepo(repo_info, tags)
+      self._repo_objs += [repo_obj]
+
+  def all_repos(self):
+    ''' return names of all repos, sorted '''
+    return sorted(
+      [obj.name for obj in self._repo_objs]
+    )
+
+  def repos_with_tag(self, tag):
+    ''' return names of repos that have the specified tag '''
+    repos = []
+    for obj in self._repo_objs:
+      if tag in obj.tags:
+        repos += [obj.name]
+    return repos
+
+  def get_repo(self, repo_name):
+    ''' return EcrRepo object whose name matches repo_name '''
+    for obj in self._repo_objs:
+      if obj.name == repo_name:
+        return obj
+
+  def get_repo_info(self, repo_name):
+    info = None
+    for obj in self._repo_objs:
+      if obj.name == repo_name:
+        info = obj.info
+        break
+    return info
+
+  def get_repo_tags(self, repo_name):
+    tags = None
+    for obj in self._repo_objs:
+      if obj.name == repo_name:
+        tags = obj.tags
+    return tags

--- a/src/lib/ecr_repos.py
+++ b/src/lib/ecr_repos.py
@@ -34,18 +34,6 @@ class ECRRepos():
       if repo.name == repo_name:
         return repo
 
-  def get_repo_info(self, repo_name):
-    ''' return info of repo that has repo_name '''
-    for repo in self._repos:
-      if repo.name == repo_name:
-        return repo.info
-
-  def get_repo_tags(self, repo_name):
-    ''' return tags of repo that has repo_name '''
-    for repo in self._repos:
-      if repo.name == repo_name:
-        return repo.tags
-
   def repos_with_tag(self, tag):
     ''' return names of repos that have the specified tag '''
     return sorted([

--- a/src/lib/ecr_repos.py
+++ b/src/lib/ecr_repos.py
@@ -1,5 +1,3 @@
-import logging
-
 class ECRRepo():
   ''' manage 1 ECR repository's data '''
   def __init__(self, repo_info, tags):

--- a/src/lib/test/fixtures/ecr_interface.py
+++ b/src/lib/test/fixtures/ecr_interface.py
@@ -1,0 +1,66 @@
+import datetime
+import pytest
+
+from dateutil.tz import tzlocal
+
+@pytest.fixture
+def mock_boto3_client(
+  mock_ecr_describe_repositories_result,
+  mock_ecr_list_tags_for_resource_result
+):
+  class MockECRClient():
+    def __init__(self):
+      pass
+    def describe_repositories(self, *args):
+      return mock_ecr_describe_repositories_result
+    def list_tags_for_resource(self, **kwargs):
+      return mock_ecr_list_tags_for_resource_result
+  return MockECRClient()
+
+@pytest.fixture
+def mock_ecr_describe_repositories_result():
+  obj = {
+    'repositories': [
+      {
+        'repositoryArn': 'arn:aws:ecr:us-east-1:123:repository/foo1',
+        'registryId': '123',
+        'repositoryName': 'foo1',
+        'repositoryUri': '123.dkr.ecr.us-east-1.amazonaws.com/foo1',
+        'createdAt': datetime.datetime(2023, 6, 13, 16, 50, 21, tzinfo=tzlocal()),
+        'imageTagMutability': 'MUTABLE',
+        'imageScanningConfiguration': {'scanOnPush': False},
+        'encryptionConfiguration': {'encryptionType': 'AES256'}
+      },
+      {
+        'repositoryArn': 'arn:aws:ecr:us-east-1:123:repository/foo2',
+        'registryId': '123',
+        'repositoryName': 'foo2',
+        'repositoryUri': '123.dkr.ecr.us-east-1.amazonaws.com/foo2',
+        'createdAt': datetime.datetime(2023, 6, 13, 16, 50, 21, tzinfo=tzlocal()),
+        'imageTagMutability': 'MUTABLE',
+        'imageScanningConfiguration': {'scanOnPush': False},
+        'encryptionConfiguration': {'encryptionType': 'AES256'}
+      }
+    ]
+  }
+  return obj
+
+@pytest.fixture
+def mock_ecr_list_tags_for_resource_result():
+  obj = {
+    'tags': [
+      {'Key': 'env', 'Value': 'test'}
+    ],
+    'ResponseMetadata': {
+      'RequestId': 'a9918a87-e51e-4ec0-8c95-34110ae253d1',
+      'HTTPStatusCode': 200,
+      'HTTPHeaders': {
+        'x-amzn-requestid': 'a9918a87-e51e-4ec0-8c95-34110ae253d1',
+        'date': 'Wed, 14 Jun 2023 18:31:40 GMT',
+        'content-type': 'application/x-amz-json-1.1',
+        'content-length': '39'
+      },
+      'RetryAttempts': 0
+    }
+  }
+  return obj

--- a/src/lib/test/test_ecr_interface.py
+++ b/src/lib/test/test_ecr_interface.py
@@ -1,31 +1,41 @@
-import boto3
+import lib.test.fixtures.ecr_interface
 
 from lib.ecr_interface import ECRInterface
 from lib.test.fixtures.ecr_interface import (
-  mock_boto3_client,
+  mock_ecr_client,
   mock_ecr_describe_repositories_result, # indirect
-  mock_ecr_list_tags_for_resource_result # indirect
+  mock_ecr_list_tags_for_resource_result, # indirect
 )
 
 def describe_ecr_interface():
-  def describe_get_repos():
-    def it_gets(mocker, mock_boto3_client):
+  def describe_instantiation():
+    def it_instantiates(mocker, mock_ecr_client):
       mocker.patch(
-        'lib.ecr_interface.boto3.client',
-        return_value=mock_boto3_client
+        'lib.ecr_interface.boto3client',
+        return_value=mock_ecr_client
+      )
+      spy = mocker.spy(lib.ecr_interface, 'boto3client')
+      ecr_interface = ECRInterface()
+      spy.assert_has_calls([mocker.call('ecr')])
+  def describe_get_repos():
+    def it_gets(mocker, mock_ecr_client):
+      mocker.patch(
+        'lib.ecr_interface.boto3client',
+        return_value=mock_ecr_client
       )
       ecr_interface = ECRInterface()
       repos = ecr_interface.get_repos()
       assert len(repos) == 2
       assert repos[0]['repositoryName'] == 'foo1'
   def describe_get_repo_tags():
-    def it_gets(mocker, mock_boto3_client):
+    def it_gets(mocker, mock_ecr_client):
       mocker.patch(
-        'lib.ecr_interface.boto3.client',
-        return_value=mock_boto3_client
+        'lib.ecr_interface.boto3client',
+        return_value=mock_ecr_client
       )
       ecr_interface = ECRInterface()
-      res = ecr_interface.get_repo_tags('foo1')
+      arn = 'arn:aws:ecr:us-east-1:123:repository/foo1'
+      res = ecr_interface.get_repo_tags(arn)
       assert res['tags'][0] == {
         'Key': 'env', 'Value': 'test'
       }

--- a/src/lib/test/test_ecr_interface.py
+++ b/src/lib/test/test_ecr_interface.py
@@ -1,0 +1,31 @@
+import boto3
+
+from lib.ecr_interface import ECRInterface
+from lib.test.fixtures.ecr_interface import (
+  mock_boto3_client,
+  mock_ecr_describe_repositories_result, # indirect
+  mock_ecr_list_tags_for_resource_result # indirect
+)
+
+def describe_ecr_interface():
+  def describe_get_repos():
+    def it_gets(mocker, mock_boto3_client):
+      mocker.patch(
+        'lib.ecr_interface.boto3.client',
+        return_value=mock_boto3_client
+      )
+      ecr_interface = ECRInterface()
+      repos = ecr_interface.get_repos()
+      assert len(repos) == 2
+      assert repos[0]['repositoryName'] == 'foo1'
+  def describe_get_repo_tags():
+    def it_gets(mocker, mock_boto3_client):
+      mocker.patch(
+        'lib.ecr_interface.boto3.client',
+        return_value=mock_boto3_client
+      )
+      ecr_interface = ECRInterface()
+      res = ecr_interface.get_repo_tags('foo1')
+      assert res['tags'][0] == {
+        'Key': 'env', 'Value': 'test'
+      }

--- a/src/lib/test/test_ecr_repos.py
+++ b/src/lib/test/test_ecr_repos.py
@@ -1,0 +1,48 @@
+from lib.ecr_repos import ECRRepo, ECRRepos
+
+from lib.test.fixtures.ecr_interface import (
+  mock_ecr_client, # indirect
+  mock_ecr_describe_repositories_result,
+  mock_ecr_interface,
+  mock_ecr_list_tags_for_resource_result
+)
+
+def describe_ecr_repo():
+  def describe_instantiation():
+    def it_instantiates(
+      mock_ecr_describe_repositories_result,
+      mock_ecr_list_tags_for_resource_result
+    ):
+      repo_infos = mock_ecr_describe_repositories_result
+      repo1_info = repo_infos['repositories'][0]
+      res = mock_ecr_list_tags_for_resource_result
+      repo1_tags = res['tags']
+      ecr_repo = ECRRepo(repo1_info, repo1_tags)
+      assert ecr_repo.arn == repo1_info['repositoryArn']
+      assert ecr_repo.info == repo1_info
+      assert ecr_repo.name == repo1_info['repositoryName']
+      assert ecr_repo.tags == repo1_tags
+
+def describe_ecr_repos():
+  def describe_instantiation():
+    def it_instantiates(mock_ecr_interface):
+      ecr_repos = ECRRepos(mock_ecr_interface)
+      repo1 = ecr_repos._repos[0]
+      assert len(ecr_repos._repos) == 2
+      assert isinstance(repo1, ECRRepo)
+  def describe_all_repos():
+    def it_returns_all_repos(mock_ecr_interface):
+      ecr_repos = ECRRepos(mock_ecr_interface)
+      assert set(ecr_repos.all_repos()) == set(['foo2', 'foo1'])
+  def describe_get_repo():
+    def it_gets_correct_repo(mock_ecr_interface):
+      ecr_repos = ECRRepos(mock_ecr_interface)
+      repo = ecr_repos.get_repo('foo1')
+      assert repo.name == 'foo1'
+  def describe_repos_wit_tag():
+    def it_gets_correct_repos(mock_ecr_interface):
+      ecr_repos = ECRRepos(mock_ecr_interface)
+      tag = {'Key': 'env', 'Value': 'test'}
+      repos = ecr_repos.repos_with_tag(tag)
+      assert len(repos) == 1
+      assert repos[0] == 'foo1'

--- a/src/lib/test/test_util.py
+++ b/src/lib/test/test_util.py
@@ -19,11 +19,19 @@ def describe_list_match_str():
     ]
 
 def describe_list_subtract():
-  def it_subtracts_when_a_is_superset_of_b():
+  def it_returns_a_when_nothing_to_subtract():
+    a = [1, 2, 3]
+    assert list_subtract(a) == a
+  def it_subtracts_one():
     a = [1, 2, 3]
     b = [1, 3]
     assert list_subtract(a,b) == [2]
-  def it_ignores_elements_in_b_not_in_a():
+  def it_subtracts_multiple():
+    a = [1, 2, 3, 4]
+    b = [1, 3]
+    c = [2]
+    assert list_subtract(a,b,c) == [4]
+  def it_ignores_elements_not_in_a():
     a = [1, 2, 3]
     b = [1, 3, 4, 5]
     assert list_subtract(a,b) == [2]

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -2,9 +2,15 @@ def list_intersect(list_a, list_b):
   ''' return elements common between l1 and l2 '''
   return [ x for x in list_a if x in list_b]
 
-def list_subtract(list_a, list_b):
-  ''' return elements that are in list a but not b '''
-  return [x for x in list_a if x not in list_b]
+def list_subtract(list_a, *args):
+  '''
+  return elements that are in list a but
+  not in any list supplied by *args
+  '''
+  minuend = list_a
+  for subtrahend in args:
+    minuend = [x for x in minuend if x not in subtrahend]
+  return minuend
 
 def list_match_str(list_a, str1):
   ''' return elements of list_a that match string str1 '''


### PR DESCRIPTION
[PLATFORM-5010]

- Add a script that checks for ECR repos that don't have any of the following tags:
  - `managed_by: terraform`
  - `env: test`
- Add a cronjob in Prod environment to run the ^^ script daily, before business hours. Upon finding repos that don't have the mentioned tags, the job shall alert, and engineers are expected to check whether those repos should be added to Terraform.

Local test run:

```
# when jiantest repo has no tags
$ src/ecr_check_repos_for_terraform/check.py ; echo $?
INFO:root:Checking ECR for repositories that perhaps should be added to Terraform...
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:root:Repositories found: ['jiantest']
1

# when jiantest repo has "env: test" tag
$ src/ecr_check_repos_for_terraform/check.py ; echo $?
INFO:root:Checking ECR for repositories that perhaps should be added to Terraform...
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:root:None found.
0
```

[PLATFORM-5010]: https://artsyproduct.atlassian.net/browse/PLATFORM-5010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ