### PR TITLE
feat: several improvements in response to review of PR#32

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -17,7 +17,7 @@ spec:
           containers:
             - name: opstools-terraform-drift-detection
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
-              command: ["src/terraform_drift_detection/detect.py"]
+              command: ["python", "src/terraform_drift_detection/detect.py"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -52,7 +52,7 @@ spec:
           containers:
             - name: opstools-k8s-create-backup
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
-              command: ["src/kubernetes_backup/backup.py", "--s3"]
+              command: ["python", "src/kubernetes_backup/backup.py", "--s3"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -88,7 +88,7 @@ spec:
           containers:
             - name: opstools-k8s-prune-backup
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
-              command: ["src/kubernetes_backup/prune.py", "--force"]
+              command: ["python", "src/kubernetes_backup/prune.py", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -123,7 +123,7 @@ spec:
           containers:
             - name: opstools-cleanup-hokusai-run-pods
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
-              command: ["src/kubernetes_cleanup_pods/cleanup.py", "6", "--name=-hokusai-run", "--force"]
+              command: ["python", "src/kubernetes_cleanup_pods/cleanup.py", "6", "--name=-hokusai-run", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -159,7 +159,7 @@ spec:
           containers:
             - name: opstools-cleanup-jobs
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
-              command: ["src/kubernetes_cleanup_jobs/cleanup.py", "48", "--all", "--force"]
+              command: ["python", "src/kubernetes_cleanup_jobs/cleanup.py", "48", "--all", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -195,7 +195,7 @@ spec:
           containers:
             - name: opstools-cleanup-completed-pods
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
-              command: ["src/kubernetes_cleanup_pods/cleanup.py", "48", "--completed", "--force"]
+              command: ["python", "src/kubernetes_cleanup_pods/cleanup.py", "48", "--completed", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -231,7 +231,7 @@ spec:
           containers:
             - name: opstools-ecr-check-repos-for-terraform
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
-              command: ["src/ecr_check_repos_for_terraform/check.py"]
+              command: ["python", "src/ecr_check_repos_for_terraform/check.py"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -17,7 +17,7 @@ spec:
           containers:
             - name: opstools-terraform-drift-detection
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
-              command: ["src/terraform_drift_detection/detect.py"]
+              command: ["python", "src/terraform_drift_detection/detect.py"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -52,7 +52,7 @@ spec:
           containers:
             - name: opstools-k8s-create-backup
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
-              command: ["src/kubernetes_backup/backup.py", "--s3"]
+              command: ["python", "src/kubernetes_backup/backup.py", "--s3"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -88,7 +88,7 @@ spec:
           containers:
             - name: opstools-k8s-prune-backup
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
-              command: ["src/kubernetes_backup/prune.py", "--force"]
+              command: ["python", "src/kubernetes_backup/prune.py", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -123,7 +123,7 @@ spec:
           containers:
             - name: opstools-cleanup-review-apps
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
-              command: ["src/kubernetes_cleanup_namespaces/cleanup.py", "--force", "30"]
+              command: ["python", "src/kubernetes_cleanup_namespaces/cleanup.py", "--force", "30"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -159,7 +159,7 @@ spec:
           containers:
             - name: opstools-cleanup-hokusai-run-pods
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
-              command: ["src/kubernetes_cleanup_pods/cleanup.py", "6", "--name=-hokusai-run", "--force"]
+              command: ["python", "src/kubernetes_cleanup_pods/cleanup.py", "6", "--name=-hokusai-run", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -195,7 +195,7 @@ spec:
           containers:
             - name: opstools-cleanup-jobs
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
-              command: ["src/kubernetes_cleanup_jobs/cleanup.py", "48", "--all", "--force"]
+              command: ["python", "src/kubernetes_cleanup_jobs/cleanup.py", "48", "--all", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:
@@ -231,7 +231,7 @@ spec:
           containers:
             - name: opstools-cleanup-completed-pods
               image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
-              command: ["src/kubernetes_cleanup_pods/cleanup.py", "48", "--completed", "--force"]
+              command: ["python", "src/kubernetes_cleanup_pods/cleanup.py", "48", "--completed", "--force"]
               imagePullPolicy: Always
               envFrom:
                 - configMapRef:

--- a/src/ecr_check_repos_for_terraform/check.py
+++ b/src/ecr_check_repos_for_terraform/check.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 
 # initialize the app

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/config.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/config.py
@@ -1,5 +1,3 @@
-import os
-
 import argparse
 import logging
 

--- a/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/config.py
+++ b/src/ecr_check_repos_for_terraform/ecr_check_repos_for_terraform/config.py
@@ -7,12 +7,11 @@ import ecr_check_repos_for_terraform.context
 from lib.logging import setup_logging
 
 class AppConfig:
-  def __init__(self, cmdline_args, env):
+  def __init__(self, cmdline_args):
     ''' set app-wide configs and initialize the app '''
     loglevel = (
       cmdline_args.loglevel
     )
-
     self._init_app(loglevel)
 
   def _init_app(self, loglevel):
@@ -33,10 +32,6 @@ def parse_args():
   )
   return parser.parse_args()
 
-def parse_env(env):
-  ''' parse and validate env vars '''
-  pass
-
 # import this from main script
 # object will be instantiated only once
-config = AppConfig(parse_args(), parse_env(os.environ))
+config = AppConfig(parse_args())

--- a/src/kubernetes_backup/backup.py
+++ b/src/kubernetes_backup/backup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 

--- a/src/kubernetes_backup/kubernetes_backup/s3.py
+++ b/src/kubernetes_backup/kubernetes_backup/s3.py
@@ -4,7 +4,7 @@ import logging
 
 import boto3
 
-class S3Interface(object):
+class S3Interface():
   KEY_SUFFIX = '.tar.gz'
 
   def __init__(self, bucket_name, prefix=''):

--- a/src/kubernetes_backup/kubernetes_backup/s3.py
+++ b/src/kubernetes_backup/kubernetes_backup/s3.py
@@ -4,7 +4,7 @@ import logging
 
 import boto3
 
-class S3Interface():
+class S3Interface:
   KEY_SUFFIX = '.tar.gz'
 
   def __init__(self, bucket_name, prefix=''):

--- a/src/kubernetes_backup/prune.py
+++ b/src/kubernetes_backup/prune.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import os
 import sys
 

--- a/src/kubernetes_cleanup_jobs/cleanup.py
+++ b/src/kubernetes_cleanup_jobs/cleanup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 from kubernetes_cleanup_jobs.config import config
 
 from kubernetes_cleanup_jobs.jobs import (

--- a/src/kubernetes_cleanup_namespaces/cleanup.py
+++ b/src/kubernetes_cleanup_namespaces/cleanup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # initialize the app
 from kubernetes_cleanup_namespaces.config import config
 

--- a/src/kubernetes_cleanup_namespaces/kubernetes_cleanup_namespaces/test/fixtures/namespaces.py
+++ b/src/kubernetes_cleanup_namespaces/kubernetes_cleanup_namespaces/test/fixtures/namespaces.py
@@ -2,7 +2,7 @@ import pytest
 
 @pytest.fixture
 def mock_ns_object(mock_kctl_object):
-  class MockNamespaces():
+  class MockNamespaces:
     def __init__(self):
       pass
     def created_at(self, namespace):
@@ -11,7 +11,7 @@ def mock_ns_object(mock_kctl_object):
 
 @pytest.fixture
 def mock_kctl_object():
-  class MockKctl():
+  class MockKctl:
     def __init__(self):
       pass
     def delete_namespace(self, name):

--- a/src/kubernetes_cleanup_pods/cleanup.py
+++ b/src/kubernetes_cleanup_pods/cleanup.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 # initialize the app
 from kubernetes_cleanup_pods.config import config
 

--- a/src/lib/ecr_interface.py
+++ b/src/lib/ecr_interface.py
@@ -1,6 +1,6 @@
 from boto3 import client as boto3_client
 
-class ECRInterface(object):
+class ECRInterface():
   ''' interface with AWS ECR '''
 
   def __init__(self):

--- a/src/lib/ecr_interface.py
+++ b/src/lib/ecr_interface.py
@@ -1,6 +1,6 @@
 from boto3 import client as boto3_client
 
-class ECRInterface():
+class ECRInterface:
   ''' interface with AWS ECR '''
 
   def __init__(self):

--- a/src/lib/ecr_interface.py
+++ b/src/lib/ecr_interface.py
@@ -1,10 +1,10 @@
-from boto3 import client as boto3client
+from boto3 import client as boto3_client
 
 class ECRInterface(object):
   ''' interface with AWS ECR '''
 
   def __init__(self):
-    self._ecr = boto3client('ecr')
+    self._ecr = boto3_client('ecr')
 
   def get_repos(self):
     repos = []

--- a/src/lib/ecr_repos.py
+++ b/src/lib/ecr_repos.py
@@ -1,4 +1,4 @@
-class ECRRepo():
+class ECRRepo:
   ''' manage 1 ECR repository's data '''
   def __init__(self, repo_info, tags):
     self.arn = repo_info['repositoryArn']
@@ -6,7 +6,7 @@ class ECRRepo():
     self.name = repo_info['repositoryName']
     self.tags = tags
 
-class ECRRepos():
+class ECRRepos:
   ''' manage all ECR repositories' data '''
   def __init__(self, ecr_interface):
     self._ecr_interface = ecr_interface

--- a/src/lib/k8s_jobs.py
+++ b/src/lib/k8s_jobs.py
@@ -2,7 +2,7 @@ import logging
 
 from dateutil.parser import parse as parsedatetime
 
-class Jobs():
+class Jobs:
   ''' manage jobs data '''
   def __init__(self, kctl, namespace):
     self._jobs_data = kctl.get_jobs(namespace)

--- a/src/lib/k8s_namespaces.py
+++ b/src/lib/k8s_namespaces.py
@@ -1,6 +1,6 @@
 from dateutil.parser import parse as parsedatetime
 
-class Namespaces():
+class Namespaces:
   ''' manage namespaces data '''
   def __init__(self, kctl):
     # load namespaces data using the given kctl client

--- a/src/lib/k8s_pods.py
+++ b/src/lib/k8s_pods.py
@@ -2,7 +2,7 @@ import logging
 
 from dateutil.parser import parse as parsedatetime
 
-class Pods():
+class Pods:
   ''' manage pods data '''
   def __init__(self, kctl, namespace):
     self._pods_data = kctl.get_pods(namespace)

--- a/src/lib/kctl.py
+++ b/src/lib/kctl.py
@@ -4,7 +4,7 @@ import sys
 
 from subprocess import check_output, SubprocessError
 
-class Kctl():
+class Kctl:
   ''' interface with kubectl '''
   def __init__(self, context):
     logging.debug(f"Kctl > __init__: context: {context}")

--- a/src/lib/test/fixtures/ecr_interface.py
+++ b/src/lib/test/fixtures/ecr_interface.py
@@ -8,7 +8,7 @@ def mock_ecr_client(
   mock_ecr_describe_repositories_result,
   mock_ecr_list_tags_for_resource_result
 ):
-  class MockECRClient():
+  class MockECRClient:
     def __init__(self):
       pass
     def describe_repositories(self, *args):
@@ -74,7 +74,7 @@ def mock_ecr_interface(
   mock_ecr_describe_repositories_result,
   mock_ecr_list_tags_for_resource_result
 ):
-  class ECRInterface():
+  class ECRInterface:
     def __init__(self):
       pass
     def get_repos(self):

--- a/src/lib/test/fixtures/kctl.py
+++ b/src/lib/test/fixtures/kctl.py
@@ -9,7 +9,7 @@ def mock_kctl(
   mock_kubectl_get_pods_json_object,
   mock_kubectl_get_jobs_json_object
 ):
-  class MockKctl():
+  class MockKctl:
     def __init__(self):
       pass
     def delete_pod(self, namespace, pod_name):

--- a/src/lib/test/test_ecr_interface.py
+++ b/src/lib/test/test_ecr_interface.py
@@ -11,16 +11,16 @@ def describe_ecr_interface():
   def describe_instantiation():
     def it_instantiates(mocker, mock_ecr_client):
       mocker.patch(
-        'lib.ecr_interface.boto3client',
+        'lib.ecr_interface.boto3_client',
         return_value=mock_ecr_client
       )
-      spy = mocker.spy(lib.ecr_interface, 'boto3client')
+      spy = mocker.spy(lib.ecr_interface, 'boto3_client')
       ecr_interface = ECRInterface()
       spy.assert_has_calls([mocker.call('ecr')])
   def describe_get_repos():
     def it_gets(mocker, mock_ecr_client):
       mocker.patch(
-        'lib.ecr_interface.boto3client',
+        'lib.ecr_interface.boto3_client',
         return_value=mock_ecr_client
       )
       ecr_interface = ECRInterface()
@@ -30,7 +30,7 @@ def describe_ecr_interface():
   def describe_get_repo_tags():
     def it_gets(mocker, mock_ecr_client):
       mocker.patch(
-        'lib.ecr_interface.boto3client',
+        'lib.ecr_interface.boto3_client',
         return_value=mock_ecr_client
       )
       ecr_interface = ECRInterface()

--- a/src/terraform_drift_detection/detect.py
+++ b/src/terraform_drift_detection/detect.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import logging
 
 from terraform_drift_detection.init import init


### PR DESCRIPTION
Improvements in response to comments in https://github.com/artsy/opstools/pull/32

- For Python scripts run as Kubernetes CronJobs, explicitly call `python` to run them.
- Remove superfluous class inheritance of `object`.
- For `ecr_check_repos_for_terraform`:
  - Remove unused `parse_env` function.
  - Make `boto3client` snake case.