### PR TITLE
fix: k8s apply fail due to un-quoted number args of command

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -272,7 +272,6 @@ spec:
               envFrom:
                 - configMapRef:
                     name: opstools-environment
-          serviceAccountName: opstools
           restartPolicy: Never
           affinity:
             nodeAffinity:
@@ -312,7 +311,6 @@ spec:
               envFrom:
                 - configMapRef:
                     name: opstools-environment
-          serviceAccountName: opstools
           restartPolicy: Never
           affinity:
             nodeAffinity:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -100,7 +100,7 @@ spec:
               - src/s3_prune_backups/prune.py
               - k8s
               - production
-              - 30
+              - "30"
               - tar.gz
               - --force
               imagePullPolicy: Always
@@ -141,7 +141,7 @@ spec:
               - python
               - src/kubernetes_cleanup_pods/cleanup.py
               - production
-              - 6
+              - "6"
               - --force
               - --in_cluster
               - --name=-hokusai-run
@@ -184,7 +184,7 @@ spec:
               - python
               - src/kubernetes_cleanup_jobs/cleanup.py
               - production
-              - 48
+              - "48"
               - --force
               - --in_cluster
               imagePullPolicy: Always
@@ -226,7 +226,7 @@ spec:
               - python
               - src/kubernetes_cleanup_pods/cleanup.py
               - production
-              - 48
+              - "48"
               - --completed
               - --force
               - --in_cluster
@@ -348,7 +348,7 @@ spec:
               - src/s3_prune_backups/prune.py
               - rabbitmq
               - production
-              - 30
+              - "30"
               - json
               - --force
               imagePullPolicy: Always

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -316,7 +316,6 @@ spec:
               envFrom:
                 - configMapRef:
                     name: opstools-environment
-          serviceAccountName: opstools
           restartPolicy: Never
           affinity:
             nodeAffinity:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -100,7 +100,7 @@ spec:
               - src/s3_prune_backups/prune.py
               - k8s
               - staging
-              - 10
+              - "10"
               - tar.gz
               - --force
               imagePullPolicy: Always
@@ -141,7 +141,7 @@ spec:
               - python
               - src/kubernetes_cleanup_namespaces/cleanup.py
               - staging
-              - 30
+              - "30"
               - --force
               - --in_cluster
               imagePullPolicy: Always
@@ -183,7 +183,7 @@ spec:
               - python
               - src/kubernetes_cleanup_pods/cleanup.py
               - staging
-              - 6
+              - "6"
               - --force
               - --in_cluster
               - --name=-hokusai-run
@@ -226,7 +226,7 @@ spec:
               - python
               - src/kubernetes_cleanup_jobs/cleanup.py
               - staging
-              - 48
+              - "48"
               - --force
               - --in_cluster
               imagePullPolicy: Always
@@ -268,7 +268,7 @@ spec:
               - python
               - src/kubernetes_cleanup_pods/cleanup.py
               - staging
-              - 48
+              - "48"
               - --completed
               - --force
               - --in_cluster
@@ -352,7 +352,7 @@ spec:
               - src/s3_prune_backups/prune.py
               - rabbitmq
               - staging
-              - 10
+              - "10"
               - json
               - --force
               imagePullPolicy: Always


### PR DESCRIPTION
Un-quoted number args cause [failure](https://app.circleci.com/pipelines/github/artsy/opstools/271/workflows/a2372fb7-a29d-408c-966c-4e7f94647b05/jobs/423).

Also, remove `opstools` service account from cronjobs that don't require it.