### PR TITLE
feat: update list of staging protected namespaces

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -5,7 +5,7 @@ The type of this PR is: **TYPE**
 <!-- If applicable, write the Jira ticket number in square brackets e.g. `[PLATFORM-123]`
      The Jira integration will turn it into a clickable link for you. -->
 
-This PR solves [PLATFORM-1234]
+This PR solves [PHIRE-1234]
 
 ### Description
 

--- a/src/kubernetes_cleanup_namespaces/kubernetes_cleanup_namespaces/config.py
+++ b/src/kubernetes_cleanup_namespaces/kubernetes_cleanup_namespaces/config.py
@@ -24,13 +24,14 @@ class AppConfig:
     )
     self.protected_namespaces = [
       'cert-manager',
-      'data-application',
       'default',
+      'external-secrets',
       'ingress-nginx',
       'kube-node-lease',
       'kube-public',
       'kubernetes-dashboard',
-      'kube-system'
+      'kube-system',
+      'vault'
     ]
     self._init_app(loglevel)
 


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR supports [PHIRE-127]

### Description

- Update list of protected namespaces in Staging.
  - Remove `data-application` as it's decom'd.
  - Add `vault` which is used by [Hashicorp Vault resources](https://github.com/artsy/substance/blob/main/clusters/staging/federation/kubernetes-staging-leo.artsy.systems/services/vault.yml).
  - Add `external-secrets` which will be used by [Kubernetes External Secrets Operator](https://www.notion.so/artsy/Hashicorp-Vault-Spike-For-Kubernetes-Apps-2b996f1f7f4c43bfb6a7c0fcd61c7282?pvs=4#5205c7612fc24185b49aca46a4408068).
- Update PR template to reflect `PLATFORM` -> `PHIRE` change in JIRA.

[PHIRE-127]: https://artsyproduct.atlassian.net/browse/PHIRE-127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ