### PR TITLE
chore: add circleci namespace to protected namespace

### DIFF
--- a/src/kubernetes_cleanup_namespaces/kubernetes_cleanup_namespaces/config.py
+++ b/src/kubernetes_cleanup_namespaces/kubernetes_cleanup_namespaces/config.py
@@ -24,6 +24,7 @@ class AppConfig:
     )
     self.protected_namespaces = [
       'cert-manager',
+      'circleci',
       'default',
       'external-secrets',
       'ingress-nginx',


### PR DESCRIPTION
The type of this PR is: chore

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PLATFORM-123]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description. Please be reminded to filter out sensitive information, as this is a public repository. -->
Small PR to add the newly created `circleci` namespace ([PR](https://github.com/artsy/substance/pull/339)) to the `protected_namespaces` [list](https://github.com/artsy/opstools/blob/main/src/kubernetes_cleanup_namespaces/kubernetes_cleanup_namespaces/config.py#L25) in the `kubernetes_cleanup_namespaces` job. 

Though perhaps this is no longer needed if we plan to update the job to respect tags, as started in this  `hokusai` [PR](https://github.com/artsy/hokusai/pull/370)?




[PLATFORM-123]: https://artsyproduct.atlassian.net/browse/PLATFORM-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ