### PR TITLE
feat: example script to bulk-update deprecated kubernetes specs

### DIFF
--- a/src/hokusai-app-updater/examples/replace_deprecated_specs/project_list
+++ b/src/hokusai-app-updater/examples/replace_deprecated_specs/project_list
@@ -1,0 +1,1 @@
+horizon

--- a/src/hokusai-app-updater/examples/replace_deprecated_specs/replace_deprecated_specs.sh
+++ b/src/hokusai-app-updater/examples/replace_deprecated_specs/replace_deprecated_specs.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Depends on GNU-sed installed as gsed (via `brew install gnu-sed`).
+
+deprecations=(
+#   "apiVersion: batch/v1beta1"
+  "apiVersion: networking.k8s.io/v1beta1"
+  "              serviceName: "
+  "              servicePort: "
+  "            serviceName: "
+  "            servicePort: "
+  "          serviceName: "
+  "          servicePort: "
+)
+
+replacements=(
+#   "apiVersion: batch/v1"
+  "apiVersion: networking.k8s.io/v1"
+  "              service:\n                name: "
+  "                port:\n                  name: "
+  "            service:\n              name: "
+  "              port:\n                name: "
+  "          service:\n            name: "
+  "            port:\n              name: "
+)
+
+for i in "${!deprecations[@]}"; do
+  echo "Replacing '${deprecations[i]}' with '${replacements[i]}'"
+
+  gsed -z -i -e "s|${deprecations[i]}|${replacements[i]}|" hokusai/staging.yml*
+  gsed -z -i -e "s|${deprecations[i]}|${replacements[i]}|" hokusai/production.yml*
+done
+
+


### PR DESCRIPTION
This PR adds an example script for bulk-updating deprecated kubernetes specs in a list of projects. It's based on [this list of pending kubernetes API deprecations](https://www.notion.so/artsy/Kubernetes-Upkeep-002405eef7fb48fca658e428c1787c40?pvs=4#0574a294e59d43038dea9bfd4d24fe82).
* See https://github.com/kubernetes/kubernetes/pull/89778 for detail about ingress spec changes. Almost all our ingress declarations use a port _name_ rather than _number_, so this is naïve but effective. Only Motion and a few Substance specs use numbers.
* Despite the `batch/v1beta1` API being deprecated, switching our `CronJob`s away from it results in `no matches for kind "CronJob" in version "batch/v1"` errors. [Apparently](https://stackoverflow.com/questions/67520866/no-matches-for-kind-cronjob-in-version-batch-v1#comment119363607_67521713) `CronJob` is not an available resource under the new API yet in 1.19.*.

Example pull request: https://github.com/artsy/horizon/pull/598

Example command:

```bash
./update_apps.sh examples/replace_deprecated_specs/replace_deprecated_specs.sh examples/replace_deprecated_specs/project_list ~/artsy/2023-09-21_k8s_deprecations/dev deprecations "replace deprecated k8s specs" joeyAghion artsyjian
```

Tested like:

```bash
hokusai staging update --dry-run --skip-checks --verbose
```

Notes:
* Mac's `sed` couldn't handle multi-line inputs so this depends on GNU-sed.
* Unfortunate indentation differences between our projects required that I match a few whitespace varieties. (Compare [gravity](https://github.com/artsy/gravity/blob/f6006bcf1d921aa7600016152591c7c441f300c2/hokusai/production.yml#L202) to [horizon](https://github.com/artsy/horizon/blob/main/hokusai/production.yml#L156).) There's probably a smarter way to do that, but not sure I know it.
