### PR TITLE
feat: improve app updater docs and add MERGE_ON_GREEN option

### DIFF
--- a/src/hokusai-app-updater/README.md
+++ b/src/hokusai-app-updater/README.md
@@ -75,3 +75,22 @@ user@artsy:~/code/convection$ pwd
 ```
 
 When making changes to `convection` for example, the script will go into `/home/user/code/convection`. Therefore, project names in the list must match dir names in source root.
+
+> [!NOTE]
+> A checkout of each project _must_ exist in the specified directory, in a clean state, and without a branch matching the specified name. To ensure this is the case, it might be convenient to freshly clone the projects to a new location instead. E.g.:
+>
+> ```bash
+> sed 's|\(.*\)|git@github.com:artsy/\1.git|' ~/code/opstools/src/hokusai-app-updater/examples/replace_deprecated_specs/project_list | xargs -n 1  git clone
+> ```
+
+### Examples
+
+```bash
+./update_apps.sh examples/replace_deprecated_specs/replace_deprecated_specs.sh examples/replace_deprecated_specs/project_list ~/code deprecations "Replace deprecated k8s specs" joeyAghion artsyjian
+```
+
+When making changes with _a high degree of certainty_, you can set the `MERGE_ON_GREEN` environment variable to label pull requests accordingly and save some review labor:
+
+```bash
+MERGE_ON_GREEN=1 ./update_apps.sh examples/replace_deprecated_specs/replace_deprecated_specs.sh examples/replace_deprecated_specs/project_list ~/code deprecations "Replace deprecated k8s specs" joeyAghion artsyjian
+```

--- a/src/hokusai-app-updater/examples/replace_deprecated_specs/replace_deprecated_specs.sh
+++ b/src/hokusai-app-updater/examples/replace_deprecated_specs/replace_deprecated_specs.sh
@@ -27,8 +27,7 @@ replacements=(
 for i in "${!deprecations[@]}"; do
   echo "Replacing '${deprecations[i]}' with '${replacements[i]}'"
 
-  gsed -z -i -e "s|${deprecations[i]}|${replacements[i]}|" hokusai/staging.yml*
-  gsed -z -i -e "s|${deprecations[i]}|${replacements[i]}|" hokusai/production.yml*
+  gsed -z -i -e "s|${deprecations[i]}|${replacements[i]}|g" hokusai/*.yml*
 done
 
 

--- a/src/hokusai-app-updater/update_apps.sh
+++ b/src/hokusai-app-updater/update_apps.sh
@@ -56,7 +56,15 @@ function commit() {
   # command exits 0 if yes, 1 if not.
   # assumes script is run with set -e, so script exits if 1.
   gh auth status
-  gh pr create --title "$MSG" --body "$MSG" --reviewer "$REVIEWER" --assignee "$ASSIGNEE"
+
+  LABEL_ARG=""
+  # If specified, ensure "Merge On Green" label exists and has expected capitalization
+  if [[ -n "${MERGE_ON_GREEN}" ]]
+  then
+    gh label edit "merge on green" --name "Merge On Green" || gh label create "Merge On Green" --color "247A38" --description "Merge this PR when all statuses are green"
+    LABEL_ARG='--label "Merge On Green"'
+  fi
+  eval "gh pr create --title \"$MSG\" --body \"$MSG\" --reviewer \"$REVIEWER\" --assignee \"$ASSIGNEE\" $LABEL_ARG"
 }
 
 check_input "$@"


### PR DESCRIPTION
Various improvements to the `hokusai-app-updater`:
* The `replace_deprecated_specs` script now matches multiple instances per file.
* It updates files other than `[staging|production].yml` ([like Causality's `causality-test.yml`](https://github.com/artsy/causality/blob/main/hokusai/causality-test.yml)).
* It doesn't fail when a project is missing a `production.yml` ([like dev-help-helper-bot](https://github.com/artsy/dev-help-helper-bot/tree/main/hokusai)).
* A `MERGE_ON_GREEN` env var ensures PRs are labeled accordingly.
* Enhance docs with examples of how to freshly clone the listed projects and invoke the script a few different ways.