### PR TITLE
feat: improve spec updater script to handle more deeply nested projects

### DIFF
--- a/src/hokusai-app-updater/examples/replace_deprecated_specs/replace_deprecated_specs.sh
+++ b/src/hokusai-app-updater/examples/replace_deprecated_specs/replace_deprecated_specs.sh
@@ -27,7 +27,7 @@ replacements=(
 for i in "${!deprecations[@]}"; do
   echo "Replacing '${deprecations[i]}' with '${replacements[i]}'"
 
-  gsed -z -i -e "s|${deprecations[i]}|${replacements[i]}|g" hokusai/*.yml*
+  gsed -z -i -e "s|${deprecations[i]}|${replacements[i]}|g" **/hokusai/*.yml*
 done
 
 


### PR DESCRIPTION
…like Substance and artsy-hokusai-templates.

Those projects have kubernetes specs in sub-subdirectories, and can be included in the bulk-updating script with this small modification. (Self-assigning since it's so small but of course feedback welcome.)