### PR TITLE
feat: script to add timeoutSeconds to k8s exec probe specs

### DIFF
--- a/src/hokusai-app-updater/examples/add_timeout_to_exec_probe.py
+++ b/src/hokusai-app-updater/examples/add_timeout_to_exec_probe.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+
+# run this script from the root of a local repo of a hokusai-managed project
+#
+# edit a project's staging/production hokusai specs
+# specifically on Kubernetes Deployment resources
+# specifically their livenessProbe and readinessProbe configs
+# specifically those that use 'exec' as probing method
+# add timeoutSeconds to those probes if they don't have the setting
+#
+# for example, given the below livenessProbe that uses exec
+# and a DESIRED_TIMEOUT_SECONDS of 3 seconds:
+#
+#        livenessProbe:
+#          exec:
+#            command:
+#            - pgrep
+#            - -f
+#            - sidekiq
+#          initialDelaySeconds: 30
+#          periodSeconds: 30
+#
+# produce this:
+#
+#        livenessProbe:
+#          exec:
+#            command:
+#            - pgrep
+#            - -f
+#            - sidekiq
+#          initialDelaySeconds: 30
+#          periodSeconds: 30
+#          timeoutSeconds: 3
+
+import glob
+import os
+import sys
+import yaml
+
+def probe(probe_type, container_spec):
+  ''' add missing timeoutSeconds to any existing probe type that uses exec '''
+  if probe_type in container_spec and 'exec' in container_spec[probe_type] and 'timeoutSeconds' not in container_spec[probe_type]:
+        container_spec[probe_type]['timeoutSeconds'] = DESIRED_TIMEOUT_SECONDS
+
+# adjust this to preference
+DESIRED_TIMEOUT_SECONDS = 3
+
+# all types  of probes in a Deployment spec
+PROBE_TYPES = ['livenessProbe', 'readinessProbe']
+
+base = 'hokusai'
+
+# glob all staging.yml..., production.yml..., which might not exist
+staging_files = glob.glob(base + '/staging.yml*')
+prod_files = glob.glob(base + '/production.yml*')
+
+tmpfile = base + '/tmp.yml'
+
+for files in staging_files, prod_files:
+  if files:
+    # go with the first file
+    path = files[0]
+  else:
+    # no files found, move on
+    continue
+
+  # figure env
+  if 'staging' in path:
+    env = 'staging'
+  else:
+    env = 'production'
+
+  # read in spec content
+  with open(path, 'r') as reader:
+    spec_content = reader.read()
+
+  # remove jinja syntax, otherwise yaml load fails
+  spec_content = spec_content.replace('{{ ', 'doublecurlyspace')
+  spec_content = spec_content.replace(' }}', 'spacedoublecurly')
+
+  # parse yaml
+  specobj = list(yaml.safe_load_all(spec_content))
+
+  # patch
+  for item in specobj:
+    if item['kind'] == 'Deployment':
+      container0_spec = item['spec']['template']['spec']['containers'][0]
+      PROBE_TYPES = ['livenessProbe', 'readinessProbe']
+      for type in PROBE_TYPES:
+        probe(type, container0_spec)
+
+  # write yaml
+  with open(tmpfile, 'w') as writer:
+    writer.write(yaml.safe_dump_all(specobj, sort_keys=False))
+
+  # restore jinja syntax
+  with open(tmpfile, 'r') as reader:
+    tmp_content = reader.read()
+  tmp_content = tmp_content.replace('doublecurlyspace', '{{ ')
+  tmp_content = tmp_content.replace('spacedoublecurly', ' }}')
+  with open(tmpfile, 'w') as writer:
+    writer.write(tmp_content)
+
+  # override spec
+  os.replace(tmpfile, path)

--- a/src/hokusai-app-updater/update_apps.sh
+++ b/src/hokusai-app-updater/update_apps.sh
@@ -48,7 +48,7 @@ function commit() {
   echo "### commit changes ###"
   git commit -am "$MSG" --no-verify
   echo "### push to origin ###"
-  git push --set-upstream origin "$BRANCH" --no-verify
+  git push -f --set-upstream origin "$BRANCH" --no-verify
 
   echo "### open PR ###"
 
@@ -99,6 +99,16 @@ COUNT=1
 while read PROJECT
 do
   echo "---------------- #$COUNT -------------------------"
+
+  # allow user to skip project
+  echo "### Operate on $PROJECT? ###"
+  read -p "Enter y or Y to proceed: " -n 1 -r </dev/tty
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]
+  then
+    continue
+  fi
+
   WORKDIR="$SRC_ROOT/$PROJECT"
   cd "$WORKDIR"
   echo "### Operating in directory: $WORKDIR ###"


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PHIRE-338]

### Description

- Add `add_timeout_to_exec_probe.py` which adds timeoutSeconds to k8s exec probe specs. Largely adapted from [another example script](https://github.com/artsy/opstools/blob/main/src/hokusai-app-updater/examples/patch_k8s_spec_add_version_label.py).
- Update `update_apps.sh`:
  - Prompt before operating on a project. This is useful if a previous run on the project failed (e.g. bad hokusai specs). When that happens, user re-runs `update_apps.sh`, but to avoid the error happening again, user must manually delete the project from the list. That's tedious and it results in a mangled list. So this prompt allows user to skip a problematic project without editing the original project list.
  - Force push branch. If `update_apps.sh` running on a project has pushed branch to remote, and fails subsequently, and say in this case it's a problem with the sub-script (the one that edits Hokusai specs), and user fixes it, and re-runs `update_apps.sh`, it will try to push the branch again and fail because branch already exists on remote. Force push avoids the error.

[PRs](https://github.com/pulls?q=is%3Apr+author%3Aartsyjian+archived%3Afalse+%22exec+probes+without+timeout+setting%22
) generated by the script.

[PHIRE-338]: https://artsyproduct.atlassian.net/browse/PHIRE-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ