### PR TITLE
update Dockerfile - apk build deps for poetry / cffi

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,19 @@ RUN adduser --disabled-password --gecos '' deploy
 RUN mkdir -p /src
 RUN chown deploy:deploy /src
 
+RUN apk --no-cache --quiet add \
+  curl \
+  git \
+  make \
+  gcc \
+  musl-dev \
+  libffi-dev
+
 RUN pip --no-cache-dir install poetry
 RUN pip --no-cache-dir install awscli --upgrade
 
 ARG terraform_version=0.12.31
 ARG kubectl_version=1.19.16
-
-RUN apk --no-cache --quiet add \
-  curl \
-  git \
-  make
 
 RUN curl https://releases.hashicorp.com/terraform/${terraform_version}/terraform_${terraform_version}_linux_amd64.zip \
   -o /tmp/terraform_${terraform_version}_linux_amd64.zip \


### PR DESCRIPTION
The type of this PR is: Fix

### Description

When attempting a Docker / Podman build I encounter the following error when pip-installing poetry:

```
  gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -DTHREAD_STACK_SIZE=0x100000 -fPIC -DFFI_BUILDING=1 -I/usr/include/ffi -I/usr/include/libffi -I/usr/local/include/python3.9 -c src/c/_cffi_backend.c -o build/temp.linux-aarch64-cpython-39/src/c/_cffi_backend.o
  error: command 'gcc' failed: No such file or directory
  ----------------------------------------
  ERROR: Failed building wheel for cffi
Failed to build cffi
```

`gcc` needs to be installed along with `musl-dev` and `libffi-dev` before installing poetry

Alpine / musl 🤷 

Thanks @artsyjian again for open-sourcing these tools!
