### PR TITLE
fix: remove artsy_env arg from cron command

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -140,7 +140,6 @@ spec:
               command:
               - python
               - src/kubernetes_cleanup_review_apps/cleanup.py
-              - staging
               - "30"
               - --force
               - --in_cluster


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PLATFORM-123]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves `cleanup.py` error that surfaced [here](https://artsy.slack.com/archives/CA8SANW3W/p1701683014923659).

### Description

<!-- Implementation description. Please be reminded to filter out sensitive information, as this is a public repository. -->

https://github.com/artsy/opstools/pull/75 changed arguments of the `src/kubernetes_cleanup_review_apps/cleanup.py` script but the cron still passes the removed argument, `staging`. This removes that argument from the cron.

---

Reproduced the error like:
```
➜  opstools git:(main) python src/kubernetes_cleanup_review_apps/cleanup.py staging 30
usage: cleanup.py [-h] [--force] [--in_cluster] [--loglevel {DEBUG,INFO,WARNING,ERROR,CRITICAL}] ndays
cleanup.py: error: unrecognized arguments: 30
```

Successful run:
```
➜  opstools git:(fix/reviewapp-cron) python src/kubernetes_cleanup_review_apps/cleanup.py 30
INFO:root:Deleting review apps older than 30 days
INFO:root:Would have deleted namespace update-list-of-specialists created at 2023-11-02T09:25:22Z
INFO:root:Done deleting namespaces.
```