### PR TITLE
feat: bump kubectl version to match new k8s version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip --no-cache-dir install poetry
 RUN pip --no-cache-dir install awscli --upgrade
 
 ARG terraform_version=0.12.31
-ARG kubectl_version=1.19.16
+ARG kubectl_version=1.20.15
 
 RUN apk --no-cache --quiet add \
   curl \


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PHIRE-537]

### Description

Upgraded Kubernetes version to 1.20.15. Bump kubectl version to match.

[PHIRE-537]: https://artsyproduct.atlassian.net/browse/PHIRE-537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ