### PR TITLE
feat: daily vault backup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Read and run the setup script:
 
 # Run Scripts
 
-To run a script with environment files loaded (using Foreman):
+To run a script with environment files loaded (using [Foreman](https://github.com/ddollar/foreman)):
 
 ```
 foreman run --env .env.shared,.env python src/...

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -403,3 +403,42 @@ spec:
                     operator: In
                     values:
                     - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opstools-vault-snapshot
+spec:
+  schedule: "42 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+        spec:
+          containers:
+            - name: opstools-vault-snapshot
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
+              command:
+              - python
+              - src/vault_snapshot/snap.py
+              - production
+              - --s3
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: opstools-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -407,3 +407,42 @@ spec:
                     operator: In
                     values:
                     - background
+
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: opstools-vault-snapshot
+spec:
+  schedule: "32 7 * * *"
+  concurrencyPolicy: Forbid
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      template:
+        metadata:
+          annotations:
+            "cluster-autoscaler.kubernetes.io/safe-to-evict": "false"
+        spec:
+          containers:
+            - name: opstools-vault-snapshot
+              image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
+              command:
+              - python
+              - src/vault_snapshot/snap.py
+              - staging
+              - --s3
+              imagePullPolicy: Always
+              envFrom:
+                - configMapRef:
+                    name: opstools-environment
+          restartPolicy: Never
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                - matchExpressions:
+                  - key: tier
+                    operator: In
+                    values:
+                    - background

--- a/src/kubernetes_export/export.py
+++ b/src/kubernetes_export/export.py
@@ -6,7 +6,7 @@ import kubernetes_export.context
 
 from kubernetes_export.export import export_and_backup
 from lib.logging import setup_logging
-from lib.util import is_artsy_s3_bucket
+from lib.validations import is_artsy_s3_bucket
 
 
 def parse_args():

--- a/src/kubernetes_export/export.py
+++ b/src/kubernetes_export/export.py
@@ -6,7 +6,6 @@ import kubernetes_export.context
 
 from kubernetes_export.export import export_and_backup
 from lib.logging import setup_logging
-from lib.validations import is_artsy_s3_bucket
 
 
 def parse_args():
@@ -49,8 +48,6 @@ def validate(s3, s3_bucket):
   ''' validate config obtained from env and command line '''
   if s3 and not s3_bucket:
     raise Exception("K8S_BACKUP_S3_BUCKET must be specified in the environment.")
-  if s3 and not is_artsy_s3_bucket(s3_bucket):
-    raise Exception(f"{s3_bucket} seems not an Artsy S3 bucket.")
 
 
 if __name__ == "__main__":

--- a/src/kubernetes_export/kubernetes_export/export.py
+++ b/src/kubernetes_export/kubernetes_export/export.py
@@ -20,7 +20,15 @@ def export(object_type, export_dir, kctl):
   output_file = os.path.join(export_dir, f"{object_type}.yaml")
   write_file(output_file, data, heading='---\n')
 
-def export_and_backup(KUBERNETES_OBJECTS, artsy_env, in_cluster, local_dir, s3, s3_bucket, s3_prefix):
+def export_and_backup(
+  KUBERNETES_OBJECTS,
+  artsy_env,
+  in_cluster,
+  local_dir,
+  s3,
+  s3_bucket,
+  s3_prefix
+):
   ''' export kubernetes objects to yaml files and optionally back them up to S3 '''
   export_dir = os.path.join(local_dir, artsy_env)
   mkpath(export_dir)

--- a/src/kubernetes_export/kubernetes_export/export.py
+++ b/src/kubernetes_export/kubernetes_export/export.py
@@ -6,11 +6,11 @@ from distutils.dir_util import mkpath
 
 import kubernetes_export.context
 
-from lib.kctl import Kctl
-from lib.util import (
+from lib.export_backup import (
   backup_to_s3,
   write_file
 )
+from lib.kctl import Kctl
 
 
 def export(object_type, export_dir, kctl):

--- a/src/kubernetes_export/kubernetes_export/export.py
+++ b/src/kubernetes_export/kubernetes_export/export.py
@@ -9,6 +9,8 @@ import kubernetes_export.context
 
 from lib.artsy_s3_backup import ArtsyS3Backup
 from lib.kctl import Kctl
+from lib.util import write_file
+
 
 def backup_to_s3(artsy_env, export_dir, local_dir, s3_bucket, s3_prefix):
   ''' back up yamls to S3 '''
@@ -37,11 +39,8 @@ def export(object_type, export_dir, kctl):
   ''' export object_type of k8s objects to a yaml file '''
   logging.info(f"Exporting {object_type}...")
   data = kctl.get_namespaced_object(object_type, 'yaml', 'default')
-  with open(
-    os.path.join(export_dir, f"{object_type}.yaml"), 'w'
-  ) as f:
-    f.write('---\n')
-    f.write(data)
+  output_file = os.path.join(export_dir, f"{object_type}.yaml")
+  write_file(output_file, data, heading='---\n')
 
 def export_and_backup(KUBERNETES_OBJECTS, artsy_env, in_cluster, local_dir, s3, s3_bucket, s3_prefix):
   ''' export kubernetes objects to yaml files and optionally back them up to S3 '''

--- a/src/lib/export_backup.py
+++ b/src/lib/export_backup.py
@@ -1,0 +1,77 @@
+import logging
+import os
+import shutil
+
+from distutils.dir_util import mkpath
+from pathlib import Path
+
+from lib.artsy_s3_backup import ArtsyS3Backup
+from lib.validations import is_artsy_s3_bucket
+
+
+def backup_to_s3(
+  s3_bucket,
+  s3_prefix,
+  service_name,
+  artsy_env,
+  suffix,
+  source_file,
+  source_dir,
+  cleanup=True
+):
+  ''' back up to S3 and if failure, cleanup '''
+  if not is_artsy_s3_bucket(s3_bucket):
+    raise Exception(f"{s3_bucket} seems not an Artsy S3 bucket.")
+  try:
+    artsy_s3_backup = ArtsyS3Backup(
+      s3_bucket,
+      s3_prefix,
+      service_name,
+      artsy_env,
+      suffix
+    )
+    logging.info('Backing up to S3...')
+    artsy_s3_backup.backup(source_file)
+  except:
+    raise
+  finally:
+    if cleanup:
+      logging.info(f"Deleting {source_dir} ...")
+      shutil.rmtree(source_dir)
+
+def setup_local_export_dir(local_dir, artsy_env, service_host, suffix):
+  '''
+  set up a local dir to store data export,
+  name dir after artsy environment,
+  generate output file name,
+  return dir and file name, expect client to create file.
+  '''
+  export_dir = os.path.join(local_dir, artsy_env)
+  mkpath(export_dir)
+  file_name = f"{service_host}.{suffix}"
+  output_file = os.path.join(export_dir, file_name)
+  return export_dir, output_file
+
+def write_file(output_file, data, data_format='text', heading=None, mode=0o600, exist_ok=True):
+  if data_format == 'text':
+    write_text_file(output_file, data, heading, mode, exist_ok)
+  elif data_format == 'binary':
+    write_binary_file(output_file, data, mode, exist_ok)
+  else:
+    raise Exception(f'Un-supported data format: {data_format}')
+
+def write_text_file(output_file, data, heading=None, mode=0o600, exist_ok=True):
+  ''' write heading and data to output file, create file with proper permissions '''
+  fobj = Path(output_file)
+  fobj.touch(mode=mode, exist_ok=exist_ok)
+  with open(output_file, 'w') as f:
+    if heading:
+      f.write(heading)
+    f.write(data)
+
+def write_binary_file(output_file, data, mode=0o600, exist_ok=True):
+  ''' write data to output file, create file with proper permissions '''
+  fobj = Path(output_file)
+  fobj.touch(mode=mode, exist_ok=exist_ok)
+  with open(output_file, 'wb') as f:
+    f.write(data)

--- a/src/lib/export_backup.py
+++ b/src/lib/export_backup.py
@@ -43,8 +43,8 @@ def setup_local_export_dir(local_dir, artsy_env, service_host, suffix):
   '''
   set up a local dir to store data export,
   name dir after artsy environment,
-  generate output file name,
-  return dir and file name, expect client to create file.
+  generate output file path,
+  return dir and file path, expect client to create file.
   '''
   export_dir = os.path.join(local_dir, artsy_env)
   mkpath(export_dir)
@@ -53,6 +53,7 @@ def setup_local_export_dir(local_dir, artsy_env, service_host, suffix):
   return export_dir, output_file
 
 def write_file(output_file, data, data_format='text', heading=None, mode=0o600, exist_ok=True):
+  ''' write text or binary data to file, create file with proper permissions '''
   if data_format == 'text':
     write_text_file(output_file, data, heading, mode, exist_ok)
   elif data_format == 'binary':
@@ -61,7 +62,7 @@ def write_file(output_file, data, data_format='text', heading=None, mode=0o600, 
     raise Exception(f'Un-supported data format: {data_format}')
 
 def write_text_file(output_file, data, heading=None, mode=0o600, exist_ok=True):
-  ''' write heading and data to output file, create file with proper permissions '''
+  ''' write heading and text data to output file, create file with proper permissions '''
   fobj = Path(output_file)
   fobj.touch(mode=mode, exist_ok=exist_ok)
   with open(output_file, 'w') as f:
@@ -70,7 +71,7 @@ def write_text_file(output_file, data, heading=None, mode=0o600, exist_ok=True):
     f.write(data)
 
 def write_binary_file(output_file, data, mode=0o600, exist_ok=True):
-  ''' write data to output file, create file with proper permissions '''
+  ''' write binary data to output file, create file with proper permissions '''
   fobj = Path(output_file)
   fobj.touch(mode=mode, exist_ok=exist_ok)
   with open(output_file, 'wb') as f:

--- a/src/lib/sanitizers.py
+++ b/src/lib/sanitizers.py
@@ -1,3 +1,8 @@
+import logging
+
+from lib.util import unquote
+
+
 def config_secret_sanitizer(str1):
   ''' run all config secret sanitizers '''
   artsy_sanitized = config_secret_sanitizer_artsy(str1)

--- a/src/lib/sanitizers.py
+++ b/src/lib/sanitizers.py
@@ -1,0 +1,23 @@
+def config_secret_sanitizer(str1):
+  ''' run all config secret sanitizers '''
+  artsy_sanitized = config_secret_sanitizer_artsy(str1)
+  eso_sanitized = config_secret_sanitizer_eso(artsy_sanitized)
+  return eso_sanitized
+
+def config_secret_sanitizer_artsy(str1):
+  ''' ensure secret_value conforms to Artsy requirements '''
+  # strip surrounding quotes if any
+  return unquote(str1)
+
+def config_secret_sanitizer_eso(str1):
+  ''' ensure string is acceptable to Kubernetes External Secrets Operator '''
+  # add double quoutes if string has YAML special char
+  special_chars = ['*']
+  for char in special_chars:
+    if char in str1:
+      logging.debug(
+        'String contains special YAML chars, adding double-quotes.'
+      )
+      return f'"{str1}"'
+      break
+  return str1

--- a/src/lib/test/fixtures/export_backup.py
+++ b/src/lib/test/fixtures/export_backup.py
@@ -1,0 +1,26 @@
+import pytest
+
+
+@pytest.fixture
+def mock_artsy_s3_backup_class1():
+  class MockArtsyS3Backup():
+    def __init__(self, *args):
+      init_spy(*args)
+    def backup(self, *args):
+      backup_spy(*args)
+  return MockArtsyS3Backup
+
+def init_spy(a,b,c,d,e):
+  pass
+
+def backup_spy(a):
+  pass
+
+@pytest.fixture
+def mock_artsy_s3_backup_class2():
+  class MockArtsyS3Backup():
+    def __init__(self, *args):
+      pass
+    def backup(self, *args):
+      raise Exception
+  return MockArtsyS3Backup

--- a/src/lib/test/fixtures/vault.py
+++ b/src/lib/test/fixtures/vault.py
@@ -8,32 +8,33 @@ def mock_exception_function():
 
 @pytest.fixture
 def mock_hvac_client_class():
+  class MockV2():
+    def __init__(self):
+      pass
+    def list_secrets(self, path, mount_point):
+      return ['fookey', 'barkey']
+    def create_or_update_secret(self, path, secret, mount_point):
+      pass
+
+  class MockKV():
+    def __init__(self):
+      self.v2 = MockV2()
+    def read_secret_version(self, path, mount_point):
+      response = {
+        'data': {
+          'data': {
+            'fookey': 'foovalue'
+          }
+        }
+      }
+      return response
+
+  class MockSecrets():
+    def __init__(self):
+      self.kv = MockKV()
+
   class MockClient():
     def __init__(self, url=None, token=None):
       self.secrets = MockSecrets()
+
   return MockClient
-
-class MockSecrets():
-  def __init__(self):
-    self.kv = MockKV()
-
-class MockKV():
-  def __init__(self):
-    self.v2 = MockV2()
-  def read_secret_version(self, path, mount_point):
-    response = {
-      'data': {
-        'data': {
-          'fookey': 'foovalue'
-        }
-      }
-    }
-    return response
-
-class MockV2():
-  def __init__(self):
-    pass
-  def list_secrets(self, path, mount_point):
-    return ['fookey', 'barkey']
-  def create_or_update_secret(self, path, secret, mount_point):
-    pass

--- a/src/lib/test/test_export_backup.py
+++ b/src/lib/test/test_export_backup.py
@@ -1,6 +1,90 @@
-from lib.export_backup import write_file
+import os
+import pytest
+
+import lib.export_backup
+
+from lib.export_backup import (
+  backup_to_s3,
+  setup_local_export_dir,
+  write_file,
+  write_binary_file,
+  write_text_file
+)
+from lib.test.fixtures.export_backup import (
+  backup_spy,
+  mock_artsy_s3_backup_class1,
+  mock_artsy_s3_backup_class2
+)
+
+
+def describe_backup_to_s3():
+  def it_raises_when_not_artsy_bucket(mocker):
+    mocker.patch('lib.export_backup.is_artsy_s3_bucket').return_value = False
+    with pytest.raises(Exception):
+      backup_to_s3()
+  def it_does_the_right_things(mocker, mock_artsy_s3_backup_class1):
+    mocker.patch('lib.export_backup.ArtsyS3Backup').side_effect = mock_artsy_s3_backup_class1
+    mocker.patch('lib.export_backup.is_artsy_s3_bucket').return_value = True
+    mocker.patch('lib.export_backup.shutil.rmtree')
+    init_spy = mocker.spy(lib.test.fixtures.export_backup, 'init_spy')
+    backup_spy = mocker.spy(lib.test.fixtures.export_backup, 'backup_spy')
+    rmtree_spy = mocker.spy(lib.export_backup.shutil, 'rmtree')
+    backup_to_s3('foobucket', 'fooprefix', 'fooservice', 'fooenv', 'foosuffix', 'foofile', 'foodir')
+    init_spy.assert_has_calls([
+      mocker.call('foobucket', 'fooprefix', 'fooservice', 'fooenv', 'foosuffix')
+    ])
+    backup_spy.assert_has_calls([
+      mocker.call('foofile')
+    ])
+    rmtree_spy.assert_has_calls([
+      mocker.call('foodir')
+    ])
+  def it_cleans_up_even_when_exception(mocker, mock_artsy_s3_backup_class2):
+    mocker.patch('lib.export_backup.ArtsyS3Backup').side_effect = mock_artsy_s3_backup_class2
+    mocker.patch('lib.export_backup.is_artsy_s3_bucket').return_value = True
+    mocker.patch('lib.export_backup.shutil.rmtree')
+    rmtree_spy = mocker.spy(lib.export_backup.shutil, 'rmtree')
+    with pytest.raises(Exception):
+      backup_to_s3('foobucket', 'fooprefix', 'fooservice', 'fooenv', 'foosuffix', 'foofile', 'foodir')
+    rmtree_spy.assert_has_calls([
+      mocker.call('foodir')
+    ])
+
+def describe_setup_local_export_dir():
+  def it_returns_correct_dir_file_path(mocker):
+    mocker.patch('lib.export_backup.mkpath')
+    dir_path, file_path = setup_local_export_dir('foodir', 'fooenv', 'foohost', 'foosuffix')
+    assert dir_path == 'foodir/fooenv'
+    assert file_path == 'foodir/fooenv/foohost.foosuffix'
 
 def describe_write_file():
+  def it_calls_write_text_file_when_format_is_text(mocker):
+    mocker.patch('lib.export_backup.write_text_file')
+    mocker.patch('lib.export_backup.write_binary_file')
+    text_spy = mocker.spy(lib.export_backup, 'write_text_file')
+    binary_spy = mocker.spy(lib.export_backup, 'write_binary_file')
+    write_file('foofile', 'foodata', 'text')
+    text_spy.assert_has_calls([
+      mocker.call('foofile', 'foodata', None, int(0o600), True)
+    ])
+    assert not binary_spy.called
+  def it_calls_write_binary_file_when_format_is_binary(mocker):
+    mocker.patch('lib.export_backup.write_text_file')
+    mocker.patch('lib.export_backup.write_binary_file')
+    text_spy = mocker.spy(lib.export_backup, 'write_text_file')
+    binary_spy = mocker.spy(lib.export_backup, 'write_binary_file')
+    write_file('foofile', 'foodata', 'binary')
+    binary_spy.assert_has_calls([
+      mocker.call('foofile', 'foodata', int(0o600), True)
+    ])
+    assert not text_spy.called
+  def it_raises_when_format_unsupported(mocker):
+    mocker.patch('lib.export_backup.write_text_file')
+    mocker.patch('lib.export_backup.write_binary_file')
+    with pytest.raises(Exception):
+      write_file('foofile', 'foodata', 'fooformat')
+
+def describe_write_text_file():
   def it_creates_file_with_default_permissions(tmp_path):
     file_path = os.path.join(tmp_path, 'foo.txt')
     write_file(file_path, 'foo data')
@@ -18,6 +102,24 @@ def describe_write_file():
       assert f.readline().strip() == 'foo heading'
   def it_balks_when_file_exists(tmp_path):
     file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data')
+    write_file(file_path, 'foo data')
+    with pytest.raises(FileExistsError):
+      write_file(file_path, 'foo data', exist_ok=False)
+
+def describe_write_binary_file():
+  def it_creates_file_with_default_permissions(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.bin')
+    write_binary_file(file_path, b'foo data')
+    assert os.stat(file_path).st_mode == int(0o100600)
+    with open(file_path, 'rb') as f:
+      assert f.readline() == b'foo data'
+  def it_creates_file_with_custom_permissions(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.bin')
+    write_binary_file(file_path, b'foo data', mode=0o755)
+    assert os.stat(file_path).st_mode == int(0o100755)
+  def it_balks_when_file_exists(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.bin')
     write_file(file_path, 'foo data')
     write_file(file_path, 'foo data')
     with pytest.raises(FileExistsError):

--- a/src/lib/test/test_export_backup.py
+++ b/src/lib/test/test_export_backup.py
@@ -1,0 +1,24 @@
+from lib.export_backup import write_file
+
+def describe_write_file():
+  def it_creates_file_with_default_permissions(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data')
+    assert os.stat(file_path).st_mode == int(0o100600)
+    with open(file_path, 'r') as f:
+      assert f.readline().strip() == 'foo data'
+  def it_creates_file_with_custom_permissions(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data', mode=0o755)
+    assert os.stat(file_path).st_mode == int(0o100755)
+  def it_writes_heading(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data', heading='foo heading\n')
+    with open(file_path, 'r') as f:
+      assert f.readline().strip() == 'foo heading'
+  def it_balks_when_file_exists(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data')
+    write_file(file_path, 'foo data')
+    with pytest.raises(FileExistsError):
+      write_file(file_path, 'foo data', exist_ok=False)

--- a/src/lib/test/test_sanitizers.py
+++ b/src/lib/test/test_sanitizers.py
@@ -1,0 +1,33 @@
+import lib.sanitizers
+
+from lib.sanitizers import (
+  config_secret_sanitizer,
+  config_secret_sanitizer_artsy,
+  config_secret_sanitizer_eso
+)
+
+
+def describe_config_secret_sanitizer():
+  def it_runs_all_sanitizers(mocker):
+    mocker.patch('lib.sanitizers.config_secret_sanitizer_artsy').return_value = 'artsy_sanitized'
+    spy1 = mocker.spy(lib.sanitizers, 'config_secret_sanitizer_artsy')
+    mocker.patch('lib.sanitizers.config_secret_sanitizer_eso').return_value = 'eso_sanitized'
+    spy2 = mocker.spy(lib.sanitizers, 'config_secret_sanitizer_eso')
+    sanitized_value = config_secret_sanitizer('foo')
+    spy1.assert_has_calls([
+      mocker.call('foo')
+    ])
+    spy2.assert_has_calls([
+      mocker.call('artsy_sanitized')
+    ])
+    assert sanitized_value == 'eso_sanitized'
+
+def describe_config_secret_sanitizer_artsy():
+  def it_removes_surrounding_quotes():
+    assert config_secret_sanitizer_artsy('"foo"') == 'foo'
+
+def describe_config_secret_sanitizer_eso():
+  def it_adds_double_quotes_when_special_yaml_char():
+    assert config_secret_sanitizer_eso('*foo') == '"*foo"'
+  def it_returns_same_string_otherwise():
+    assert config_secret_sanitizer_eso('foo') == 'foo'

--- a/src/lib/test/test_util.py
+++ b/src/lib/test/test_util.py
@@ -18,7 +18,8 @@ from lib.util import (
   replace_dashes_in_dict_keys_with_underscores,
   run_cmd,
   search_dirs_by_suffix,
-  unquote
+  unquote,
+  write_file
 )
 
 def describe_config_secret_sanitizer_artsy():
@@ -187,3 +188,26 @@ def describe_unquote():
     assert unquote("'foo'") == 'foo'
   def it_returns_same_string_if_unquoted():
     assert unquote('"foo') == '"foo'
+
+def describe_write_file():
+  def it_creates_file_with_default_permissions(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data')
+    assert os.stat(file_path).st_mode == int(0o100600)
+    with open(file_path, 'r') as f:
+      assert f.readline().strip() == 'foo data'
+  def it_creates_file_with_custom_permissions(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data', mode=0o755)
+    assert os.stat(file_path).st_mode == int(0o100755)
+  def it_writes_heading(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data', heading='foo heading\n')
+    with open(file_path, 'r') as f:
+      assert f.readline().strip() == 'foo heading'
+  def it_balks_when_file_exists(tmp_path):
+    file_path = os.path.join(tmp_path, 'foo.txt')
+    write_file(file_path, 'foo data')
+    write_file(file_path, 'foo data')
+    with pytest.raises(FileExistsError):
+      write_file(file_path, 'foo data', exist_ok=False)

--- a/src/lib/test/test_util.py
+++ b/src/lib/test/test_util.py
@@ -2,7 +2,6 @@ import glob
 import os
 import pytest
 import subprocess
-import tempfile
 
 from lib.util import (
   config_secret_sanitizer_artsy,
@@ -148,38 +147,34 @@ def describe_replace_dashes_in_dict_keys_with_underscores():
     assert new_dict == dict2
 
 def describe_run_cmd():
-  def it_runs():
-    with tempfile.TemporaryDirectory() as tmpdir:
-      os.chdir(tmpdir)
-      os.makedirs('foo')
-      resp = run_cmd('ls', tmpdir)
+  def it_runs(tmp_path):
+    os.chdir(tmp_path)
+    os.makedirs('foo')
+    resp = run_cmd('ls', tmp_path)
     assert resp.stdout == 'foo\n'
     assert resp.returncode == 0
-  def it_does_not_timeout():
-    with tempfile.TemporaryDirectory() as tmpdir:
-      os.chdir(tmpdir)
-      resp = run_cmd('sleep 1', tmpdir, timeout=3)
-  def it_times_out():
+  def it_does_not_timeout(tmp_path):
+    os.chdir(tmp_path)
+    resp = run_cmd('sleep 1', tmp_path, timeout=3)
+  def it_times_out(tmp_path):
     with pytest.raises(subprocess.TimeoutExpired):
-      with tempfile.TemporaryDirectory() as tmpdir:
-        os.chdir(tmpdir)
-        resp = run_cmd('sleep 3', tmpdir, timeout=1)
+      os.chdir(tmp_path)
+      resp = run_cmd('sleep 3', tmp_path, timeout=1)
 
 def describe_search_dirs_by_suffix():
-  def it_returns_dirs_that_have_matching_files():
-    with tempfile.TemporaryDirectory() as tmpdir:
-      os.chdir(tmpdir)
-      os.makedirs('foo')
-      os.makedirs('bar/bar')
-      os.makedirs('baz')
-      open('foo/file.txt', 'w').close()
-      open('bar/bar/file.txt', 'w').close()
-      open('baz/file.gz', 'w').close()
-      expected_dirs = [
-        os.path.join(tmpdir, 'bar/bar'),
-        os.path.join(tmpdir, 'foo')
-      ]
-      assert search_dirs_by_suffix(tmpdir, 'txt') == expected_dirs
+  def it_returns_dirs_that_have_matching_files(tmp_path):
+    os.chdir(tmp_path)
+    os.makedirs('foo')
+    os.makedirs('bar/bar')
+    os.makedirs('baz')
+    open('foo/file.txt', 'w').close()
+    open('bar/bar/file.txt', 'w').close()
+    open('baz/file.gz', 'w').close()
+    expected_dirs = [
+      os.path.join(tmp_path, 'bar/bar'),
+      os.path.join(tmp_path, 'foo')
+    ]
+    assert search_dirs_by_suffix(tmp_path, 'txt') == expected_dirs
 
 def describe_unquote():
   def it_removes_surrounding_double_quotes():

--- a/src/lib/test/test_util.py
+++ b/src/lib/test/test_util.py
@@ -7,7 +7,6 @@ from lib.util import (
   config_secret_sanitizer_artsy,
   config_secret_sanitizer_eso,
   dict1_in_dict2,
-  is_artsy_s3_bucket,
   is_quoted,
   list_intersect,
   list_match_str,
@@ -20,6 +19,7 @@ from lib.util import (
   unquote,
   write_file
 )
+
 
 def describe_config_secret_sanitizer_artsy():
   def it_removes_surrounding_quotes():
@@ -67,14 +67,6 @@ def describe_dict1_in_dict2():
     dict1 = {}
     dict2 = {}
     assert dict1_in_dict2(dict1, dict2)
-
-def describe_is_artsy_s3_bucket():
-  def it_returns_true_if_name_starts_with_artsy():
-    assert is_artsy_s3_bucket('artsy-foo-bucket')
-  def it_returns_false_if_name_does_not_start_with_artsy():
-    assert not is_artsy_s3_bucket('foo-bucket')
-  def it_returns_false_if_name_is_empty_string():
-    assert not is_artsy_s3_bucket('')
 
 def describe_is_quoted():
   def it_returns_double_quote_when_string_is_quoted_that():

--- a/src/lib/test/test_util.py
+++ b/src/lib/test/test_util.py
@@ -4,8 +4,6 @@ import pytest
 import subprocess
 
 from lib.util import (
-  config_secret_sanitizer_artsy,
-  config_secret_sanitizer_eso,
   dict1_in_dict2,
   is_quoted,
   list_intersect,
@@ -17,19 +15,9 @@ from lib.util import (
   run_cmd,
   search_dirs_by_suffix,
   unquote,
-  write_file
+  url_host_port
 )
 
-
-def describe_config_secret_sanitizer_artsy():
-  def it_removes_surrounding_quotes():
-    assert config_secret_sanitizer_artsy('"foo"') == 'foo'
-
-def describe_config_secret_sanitizer_eso():
-  def it_adds_double_quotes_when_special_yaml_char():
-    assert config_secret_sanitizer_eso('*foo') == '"*foo"'
-  def it_returns_same_string_otherwise():
-    assert config_secret_sanitizer_eso('foo') == 'foo'
 
 def describe_dict1_in_dict2():
   def it_returns_true_when_dict1_is_in_dict2():
@@ -176,25 +164,6 @@ def describe_unquote():
   def it_returns_same_string_if_unquoted():
     assert unquote('"foo') == '"foo'
 
-def describe_write_file():
-  def it_creates_file_with_default_permissions(tmp_path):
-    file_path = os.path.join(tmp_path, 'foo.txt')
-    write_file(file_path, 'foo data')
-    assert os.stat(file_path).st_mode == int(0o100600)
-    with open(file_path, 'r') as f:
-      assert f.readline().strip() == 'foo data'
-  def it_creates_file_with_custom_permissions(tmp_path):
-    file_path = os.path.join(tmp_path, 'foo.txt')
-    write_file(file_path, 'foo data', mode=0o755)
-    assert os.stat(file_path).st_mode == int(0o100755)
-  def it_writes_heading(tmp_path):
-    file_path = os.path.join(tmp_path, 'foo.txt')
-    write_file(file_path, 'foo data', heading='foo heading\n')
-    with open(file_path, 'r') as f:
-      assert f.readline().strip() == 'foo heading'
-  def it_balks_when_file_exists(tmp_path):
-    file_path = os.path.join(tmp_path, 'foo.txt')
-    write_file(file_path, 'foo data')
-    write_file(file_path, 'foo data')
-    with pytest.raises(FileExistsError):
-      write_file(file_path, 'foo data', exist_ok=False)
+def describe_url_host_port():
+  def it_returns_url_with_host_and_port():
+    assert url_host_port('foohost', '123') == 'https://foohost:123'

--- a/src/lib/test/test_validations.py
+++ b/src/lib/test/test_validations.py
@@ -1,0 +1,11 @@
+from lib.util import (
+  is_artsy_s3_bucket
+)
+
+def describe_is_artsy_s3_bucket():
+  def it_returns_true_if_name_starts_with_artsy():
+    assert is_artsy_s3_bucket('artsy-foo-bucket')
+  def it_returns_false_if_name_does_not_start_with_artsy():
+    assert not is_artsy_s3_bucket('foo-bucket')
+  def it_returns_false_if_name_is_empty_string():
+    assert not is_artsy_s3_bucket('')

--- a/src/lib/test/test_validations.py
+++ b/src/lib/test/test_validations.py
@@ -1,11 +1,42 @@
-from lib.util import (
-  is_artsy_s3_bucket
+import pytest
+
+from lib.validations import (
+  is_artsy_s3_bucket,
+  is_artsy_staging_internal_hostname,
+  is_artsy_production_internal_hostname,
+  hostname_agrees_with_artsy_environment
 )
 
+
 def describe_is_artsy_s3_bucket():
-  def it_returns_true_if_name_starts_with_artsy():
+  def it_returns_true_when_name_starts_with_artsy():
     assert is_artsy_s3_bucket('artsy-foo-bucket')
-  def it_returns_false_if_name_does_not_start_with_artsy():
+  def it_returns_false_when_name_does_not_start_with_artsy():
     assert not is_artsy_s3_bucket('foo-bucket')
-  def it_returns_false_if_name_is_empty_string():
+  def it_returns_false_when_name_is_empty_string():
     assert not is_artsy_s3_bucket('')
+
+def describe_is_artsy_staging_internal_hostname():
+  def it_returns_true_when_name_is():
+    assert is_artsy_staging_internal_hostname('foo.stg.artsy.systems')
+  def it_returns_false_when_name_is_not():
+    assert not is_artsy_staging_internal_hostname('foo.stg.artsy.system')
+
+def describe_is_artsy_production_internal_hostname():
+  def it_returns_true_when_name_is():
+    assert is_artsy_production_internal_hostname('foo.prd.artsy.systems')
+  def it_returns_false_when_name_is_not():
+    assert not is_artsy_production_internal_hostname('foo.prd.artsy.system')
+
+def describe_hostname_agrees_with_artsy_environment():
+  def it_returns_true_when_env_is_staging_and_name_agrees():
+    assert hostname_agrees_with_artsy_environment('foo.stg.artsy.systems', 'staging')
+  def it_returns_false_when_env_is_staging_and_name_conflicts():
+    assert not hostname_agrees_with_artsy_environment('foo.prd.artsy.systems', 'staging')
+  def it_returns_true_when_env_is_production_and_name_agrees():
+    assert hostname_agrees_with_artsy_environment('foo.prd.artsy.systems', 'production')
+  def it_returns_false_when_env_is_production_and_name_conflicts():
+    assert not hostname_agrees_with_artsy_environment('foo.stg.artsy.systems', 'production')
+  def it_raises_on_unknown_env():
+    with pytest.raises(Exception):
+      hostname_agrees_with_artsy_environment('fooname', 'fooenv')

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -7,6 +7,7 @@ import subprocess
 from pathlib import Path
 
 from lib.artsy_s3_backup import ArtsyS3Backup
+from lib.validations import is_artsy_s3_bucket
 
 
 def backup_to_s3(
@@ -20,6 +21,8 @@ def backup_to_s3(
   cleanup=True
 ):
   ''' back up to S3 and if failure, cleanup '''
+  if not is_artsy_s3_bucket(s3_bucket):
+    raise Exception(f"{s3_bucket} seems not an Artsy S3 bucket.")
   try:
     artsy_s3_backup = ArtsyS3Backup(
       s3_bucket,

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -4,6 +4,7 @@ import os
 import shutil
 import subprocess
 
+from distutils.dir_util import mkpath
 from pathlib import Path
 
 from lib.artsy_s3_backup import ArtsyS3Backup
@@ -151,6 +152,19 @@ def search_dirs_by_suffix(dirx, suffix):
   ]
   dirs = [os.path.dirname(path) for path in files]
   return sorted(list(set(dirs)))
+
+def setup_local_export_dir(local_dir, artsy_env, service_host, suffix):
+  '''
+  set up a local dir to store data export,
+  name dir after artsy environment,
+  generate output file name,
+  return dir and file name, expect client to create file.
+  '''
+  export_dir = os.path.join(local_dir, artsy_env)
+  mkpath(export_dir)
+  file_name = f"{service_host}.{suffix}"
+  output_file = os.path.join(export_dir, file_name)
+  return export_dir, output_file
 
 def unquote(str1):
   ''' remove string's surrounding quotes, if any '''

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -1,69 +1,8 @@
 import glob
 import logging
 import os
-import shutil
 import subprocess
 
-from distutils.dir_util import mkpath
-from pathlib import Path
-
-from lib.artsy_s3_backup import ArtsyS3Backup
-from lib.validations import is_artsy_s3_bucket
-
-
-def backup_to_s3(
-  s3_bucket,
-  s3_prefix,
-  service_name,
-  artsy_env,
-  suffix,
-  source_file,
-  source_dir,
-  cleanup=True
-):
-  ''' back up to S3 and if failure, cleanup '''
-  if not is_artsy_s3_bucket(s3_bucket):
-    raise Exception(f"{s3_bucket} seems not an Artsy S3 bucket.")
-  try:
-    artsy_s3_backup = ArtsyS3Backup(
-      s3_bucket,
-      s3_prefix,
-      service_name,
-      artsy_env,
-      suffix
-    )
-    logging.info('Backing up to S3...')
-    artsy_s3_backup.backup(source_file)
-  except:
-    raise
-  finally:
-    if cleanup:
-      logging.info(f"Deleting {source_dir} ...")
-      shutil.rmtree(source_dir)
-
-def config_secret_sanitizer(str1):
-  ''' run all config secret sanitizers '''
-  artsy_sanitized = config_secret_sanitizer_artsy(str1)
-  eso_sanitized = config_secret_sanitizer_eso(artsy_sanitized)
-  return eso_sanitized
-
-def config_secret_sanitizer_artsy(str1):
-  ''' ensure secret_value conforms to Artsy requirements '''
-  # strip surrounding quotes if any
-  return unquote(str1)
-
-def config_secret_sanitizer_eso(str1):
-  ''' ensure string is acceptable to Kubernetes External Secrets Operator '''
-  # add double quoutes if string has YAML special char
-  special_chars = ['*']
-  for char in special_chars:
-    if char in str1:
-      logging.debug(
-        'String contains special YAML chars, adding double-quotes.'
-      )
-      return f'"{str1}"'
-      break
-  return str1
 
 def dict1_in_dict2(dict1, dict2):
   ''' return true if all items in dict1 are in dict2 '''
@@ -153,19 +92,6 @@ def search_dirs_by_suffix(dirx, suffix):
   dirs = [os.path.dirname(path) for path in files]
   return sorted(list(set(dirs)))
 
-def setup_local_export_dir(local_dir, artsy_env, service_host, suffix):
-  '''
-  set up a local dir to store data export,
-  name dir after artsy environment,
-  generate output file name,
-  return dir and file name, expect client to create file.
-  '''
-  export_dir = os.path.join(local_dir, artsy_env)
-  mkpath(export_dir)
-  file_name = f"{service_host}.{suffix}"
-  output_file = os.path.join(export_dir, file_name)
-  return export_dir, output_file
-
 def unquote(str1):
   ''' remove string's surrounding quotes, if any '''
   quote_char = is_quoted(str1)
@@ -177,27 +103,3 @@ def unquote(str1):
 def url_host_port(hostname, port=443):
   ''' return https://hostname:port '''
   return f'https://{hostname}:{port}'
-
-def write_file(output_file, data, data_format='text', heading=None, mode=0o600, exist_ok=True):
-  if data_format == 'text':
-    write_text_file(output_file, data, heading, mode, exist_ok)
-  elif data_format == 'binary':
-    write_binary_file(output_file, data, mode, exist_ok)
-  else:
-    raise Exception(f'Un-supported data format: {data_format}')
-
-def write_text_file(output_file, data, heading=None, mode=0o600, exist_ok=True):
-  ''' write heading and data to output file, create file with proper permissions '''
-  fobj = Path(output_file)
-  fobj.touch(mode=mode, exist_ok=exist_ok)
-  with open(output_file, 'w') as f:
-    if heading:
-      f.write(heading)
-    f.write(data)
-
-def write_binary_file(output_file, data, mode=0o600, exist_ok=True):
-  ''' write data to output file, create file with proper permissions '''
-  fobj = Path(output_file)
-  fobj.touch(mode=mode, exist_ok=exist_ok)
-  with open(output_file, 'wb') as f:
-    f.write(data)

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -130,11 +130,26 @@ def unquote(str1):
     return str1[1:-1]
   return str1
 
-def write_file(output_file, data, heading=None, mode=0o600, exist_ok=True):
+def write_file(output_file, data, data_format='text', heading=None, mode=0o600, exist_ok=True):
+  if data_format == 'text':
+    write_text_file(output_file, data, heading, mode, exist_ok)
+  elif data_format == 'binary':
+    write_binary_file(output_file, data, mode, exist_ok)
+  else:
+    raise Exception(f'Un-supported data format: {data_format}')
+
+def write_text_file(output_file, data, heading=None, mode=0o600, exist_ok=True):
   ''' write heading and data to output file, create file with proper permissions '''
   fobj = Path(output_file)
   fobj.touch(mode=mode, exist_ok=exist_ok)
   with open(output_file, 'w') as f:
     if heading:
       f.write(heading)
+    f.write(data)
+
+def write_binary_file(output_file, data, mode=0o600, exist_ok=True):
+  ''' write data to output file, create file with proper permissions '''
+  fobj = Path(output_file)
+  fobj.touch(mode=mode, exist_ok=exist_ok)
+  with open(output_file, 'wb') as f:
     f.write(data)

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -1,10 +1,41 @@
 import glob
 import logging
 import os
+import shutil
 import subprocess
 
 from pathlib import Path
 
+from lib.artsy_s3_backup import ArtsyS3Backup
+
+
+def backup_to_s3(
+  s3_bucket,
+  s3_prefix,
+  service_name,
+  artsy_env,
+  suffix,
+  source_file,
+  source_dir,
+  cleanup=True
+):
+  ''' back up to S3 and if failure, cleanup '''
+  try:
+    artsy_s3_backup = ArtsyS3Backup(
+      s3_bucket,
+      s3_prefix,
+      service_name,
+      artsy_env,
+      suffix
+    )
+    logging.info('Backing up to S3...')
+    artsy_s3_backup.backup(source_file)
+  except:
+    raise
+  finally:
+    if cleanup:
+      logging.info(f"Deleting {source_dir} ...")
+      shutil.rmtree(source_dir)
 
 def config_secret_sanitizer(str1):
   ''' run all config secret sanitizers '''

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -126,6 +126,10 @@ def unquote(str1):
     return str1[1:-1]
   return str1
 
+def url_host_port(hostname, port=443):
+  ''' return https://hostname:port '''
+  return f'https://{hostname}:{port}'
+
 def write_file(output_file, data, data_format='text', heading=None, mode=0o600, exist_ok=True):
   if data_format == 'text':
     write_text_file(output_file, data, heading, mode, exist_ok)

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -34,10 +34,6 @@ def dict1_in_dict2(dict1, dict2):
   ''' return true if all items in dict1 are in dict2 '''
   return set(dict1.items()).issubset(set(dict2.items()))
 
-def is_artsy_s3_bucket(name):
-  ''' return true if bucket name starts with artsy- '''
-  return name.startswith('artsy-')
-
 def is_quoted(str1):
   ''' if string is quoted, return the quote character '''
   # double quote

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -3,6 +3,9 @@ import logging
 import os
 import subprocess
 
+from pathlib import Path
+
+
 def config_secret_sanitizer(str1):
   ''' run all config secret sanitizers '''
   artsy_sanitized = config_secret_sanitizer_artsy(str1)
@@ -126,3 +129,12 @@ def unquote(str1):
     logging.debug(f'string is quoted with {quote_char}, removing quotes')
     return str1[1:-1]
   return str1
+
+def write_file(output_file, data, heading=None, mode=0o600, exist_ok=True):
+  ''' write heading and data to output file, create file with proper permissions '''
+  fobj = Path(output_file)
+  fobj.touch(mode=mode, exist_ok=exist_ok)
+  with open(output_file, 'w') as f:
+    if heading:
+      f.write(heading)
+    f.write(data)

--- a/src/lib/validations.py
+++ b/src/lib/validations.py
@@ -12,7 +12,8 @@ def is_artsy_production_internal_hostname(name):
 
 def hostname_agrees_with_artsy_environment(name, artsy_env):
   '''
-  return true if environment is staging and name is artsy staging internal hostname
+  return true if environment is staging and
+  name is artsy staging internal hostname,
   similarly for production
   '''
   if artsy_env == 'staging':

--- a/src/lib/validations.py
+++ b/src/lib/validations.py
@@ -1,3 +1,23 @@
 def is_artsy_s3_bucket(name):
   ''' return true if bucket name starts with artsy- '''
   return name.startswith('artsy-')
+
+def is_artsy_staging_internal_hostname(name):
+  ''' return true if name ends with stg.artsy.systems'''
+  return name.endswith('stg.artsy.systems')
+
+def is_artsy_production_internal_hostname(name):
+  ''' return true if name ends with prd.artsy.systems'''
+  return name.endswith('prd.artsy.systems')
+
+def hostname_agrees_with_artsy_environment(name, artsy_env):
+  '''
+  return true if environment is staging and name is artsy staging internal hostname
+  similarly for production
+  '''
+  if artsy_env == 'staging':
+    return is_artsy_staging_internal_hostname(name)
+  elif artsy_env == 'production':
+    return is_artsy_production_internal_hostname(name)
+  else:
+    raise Exception(f'Unknown Artsy environment: {artsy_env}')

--- a/src/lib/validations.py
+++ b/src/lib/validations.py
@@ -1,0 +1,3 @@
+def is_artsy_s3_bucket(name):
+  ''' return true if bucket name starts with artsy- '''
+  return name.startswith('artsy-')

--- a/src/lib/vault.py
+++ b/src/lib/vault.py
@@ -2,7 +2,7 @@ import boto3
 import hvac
 import logging
 
-from lib.util import write_file
+from lib.export_backup import write_file
 
 
 class Vault:

--- a/src/lib/vault.py
+++ b/src/lib/vault.py
@@ -10,6 +10,7 @@ class Vault:
     addr,
     auth_method,
     token=None,
+    role=None,
     kvv2_mount_point=None,
     path=None,
     sanitizer=None
@@ -20,25 +21,26 @@ class Vault:
     # a function for sanitizing a value before setting it in Vault
     # this is org-specific
     self._sanitizer = sanitizer
-    self.login(self._client, auth_method, token)
+    self.login(self._client, auth_method, token, role)
 
-  def login(self, client, auth_method, token=None):
+  def login(self, client, auth_method, token=None, role=None):
     ''' log into Vault using the specified method '''
     if auth_method == 'iam':
-      self.iam_login()
+      self.iam_login(role)
     elif auth_method == 'token':
       self._client.token = token
     else:
       raise Exception(f'Un-supported auth method: {auth_method}')
 
-  def iam_login(self):
+  def iam_login(self, role):
     ''' log into Vault using AWS IAM keys '''
     session = boto3.Session()
     credentials = session.get_credentials()
     self._client.auth.aws.iam_login(
       credentials.access_key,
       credentials.secret_key,
-      credentials.token
+      credentials.token,
+      role=role
     )
 
   def get(self, key):

--- a/src/lib/vault.py
+++ b/src/lib/vault.py
@@ -98,3 +98,9 @@ class Vault:
         secret=entry,
         mount_point=self._mount_point,
       )
+
+  def take_snapshot(self, output_file):
+    binary_response = self._client.sys.take_raft_snapshot()
+    with open(output_file, 'wb') as f:
+      f.write(binary_response.content)
+

--- a/src/lib/vault.py
+++ b/src/lib/vault.py
@@ -23,19 +23,21 @@ class Vault:
     # a function for sanitizing a value before setting it in Vault
     # this is org-specific
     self._sanitizer = sanitizer
-    self.login(self._client, auth_method, token, role)
+    self._login(auth_method, token, role)
 
-  def login(self, client, auth_method, token=None, role=None):
+  def _login(self, auth_method, token=None, role=None):
     ''' log into Vault using the specified method '''
     if auth_method == 'iam':
-      self.iam_login(role)
+      self._iam_login(role)
     elif auth_method == 'token':
       self._client.token = token
     else:
       raise Exception(f'Un-supported auth method: {auth_method}')
 
-  def iam_login(self, role):
+  def _iam_login(self, role):
     ''' log into Vault using AWS IAM keys '''
+    if role == None:
+      raise Exception(f'No Vault role specified for IAM auth method.')
     session = boto3.Session()
     credentials = session.get_credentials()
     self._client.auth.aws.iam_login(

--- a/src/lib/vault.py
+++ b/src/lib/vault.py
@@ -2,6 +2,8 @@ import boto3
 import hvac
 import logging
 
+from lib.util import write_file
+
 
 class Vault:
   ''' Interface with Hashicorp Vault '''
@@ -101,6 +103,4 @@ class Vault:
 
   def take_snapshot(self, output_file):
     binary_response = self._client.sys.take_raft_snapshot()
-    with open(output_file, 'wb') as f:
-      f.write(binary_response.content)
-
+    write_file(output_file, binary_response.content, data_format='binary')

--- a/src/migrate_config_secrets/migrate.py
+++ b/src/migrate_config_secrets/migrate.py
@@ -62,16 +62,21 @@ def parse_env():
 
 def validate(artsy_env, vault_addr):
   ''' validate config obtained from env and command line '''
+  if not vault_addr:
+    raise Exception(
+      "The following environment variables must be specified: " +
+      "VAULT_ADDR"
+    )
   # make sure Vault address matches environment
   # in case user specifies 'staging' on the command line
   # yet supplies production Vault address in Env (and connects to Prod VPN)
   # or the other way around
   # address for staging is expected to contain 'stg'
   # that for prod contain 'prd'
-  if artsy_env == 'staging':
-    assert 'stg' in vault_addr
-  else:
-    assert 'prd' in vault_addr
+  if artsy_env == 'staging' and not 'stg' in vault_addr:
+    raise Exception(f'Vault address does not contain "stg": {vault_addr}')
+  elif artsy_env == 'production' and not 'prd' in vault_addr:
+    raise Exception(f'Vault address does not contain "prd": {vault_addr}')
 
 
 if __name__ == "__main__":

--- a/src/migrate_config_secrets/migrate_config_secrets/migrate.py
+++ b/src/migrate_config_secrets/migrate_config_secrets/migrate.py
@@ -61,25 +61,22 @@ def migrate_config_secrets(
   dry_run
 ):
   ''' migrate sensitive configs from configmap to Vault '''
-  logging.info(
-    f'Migrating {artsy_env} {artsy_project} ' +
-    'sensitive configs from k8s configmap to Vault...'
-  )
-
   kctl = Kctl(False, artsy_env)
   configmap_name = f'{artsy_project}-environment'
   configmap_obj = ConfigMap(kctl, configmap_name)
 
   secret_obj = K8sSecret(kctl, artsy_project)
-
   path = 'kubernetes/apps/' + f'{artsy_project}/'
+
+  logging.info(f'Migrating sensitive configs from {artsy_env} {configmap_name} configmap to {path} in Vault...')
+
   vault_client = Vault(
     url_host_port(vault_host, vault_port),
-    'token',
-    vault_token,
-    kvv2_mount_point,
-    path,
-    config_secret_sanitizer
+    auth_method='token',
+    token=vault_token,
+    kvv2_mount_point=kvv2_mount_point,
+    path=path,
+    sanitizer=config_secret_sanitizer
   )
 
   logging.info('Getting list of sensitive vars...')

--- a/src/migrate_config_secrets/migrate_config_secrets/migrate.py
+++ b/src/migrate_config_secrets/migrate_config_secrets/migrate.py
@@ -70,7 +70,9 @@ def migrate_config_secrets(
   secret_obj = K8sSecret(kctl, artsy_project)
   path = 'kubernetes/apps/' + f'{artsy_project}/'
 
-  logging.info(f'Migrating sensitive configs from {artsy_env} {configmap_name} configmap to {path} in Vault...')
+  logging.info(
+    f'Migrating sensitive configs from {artsy_env} {configmap_name} configmap to {path} in Vault...'
+  )
 
   vault_client = Vault(
     url_host_port(vault_host, vault_port),

--- a/src/migrate_config_secrets/migrate_config_secrets/migrate.py
+++ b/src/migrate_config_secrets/migrate_config_secrets/migrate.py
@@ -11,7 +11,8 @@ from lib.kctl import Kctl
 from lib.util import (
   config_secret_sanitizer,
   config_secret_sanitizer_artsy,
-  match_or_raise
+  match_or_raise,
+  url_host_port
 )
 from lib.vault import Vault
 
@@ -53,7 +54,8 @@ def migrate_config_secrets(
   artsy_project,
   list,
   repos_base_dir,
-  vault_addr,
+  vault_host,
+  vault_port,
   kvv2_mount_point,
   vault_token,
   dry_run
@@ -72,7 +74,7 @@ def migrate_config_secrets(
 
   path = 'kubernetes/apps/' + f'{artsy_project}/'
   vault_client = Vault(
-    vault_addr,
+    url_host_port(vault_host, vault_port),
     'token',
     vault_token,
     kvv2_mount_point,

--- a/src/migrate_config_secrets/migrate_config_secrets/migrate.py
+++ b/src/migrate_config_secrets/migrate_config_secrets/migrate.py
@@ -9,10 +9,12 @@ from lib.k8s_configmap import ConfigMap
 from lib.k8s_secret import K8sSecret
 from lib.kctl import Kctl
 from lib.util import (
-  config_secret_sanitizer,
-  config_secret_sanitizer_artsy,
   match_or_raise,
   url_host_port
+)
+from lib.sanitizers import (
+  config_secret_sanitizer,
+  config_secret_sanitizer_artsy
 )
 from lib.vault import Vault
 

--- a/src/migrate_config_secrets/migrate_config_secrets/migrate.py
+++ b/src/migrate_config_secrets/migrate_config_secrets/migrate.py
@@ -73,8 +73,10 @@ def migrate_config_secrets(
   path = 'kubernetes/apps/' + f'{artsy_project}/'
   vault_client = Vault(
     vault_addr,
+    'token',
+    vault_token,
     kvv2_mount_point,
-    path, vault_token,
+    path,
     config_secret_sanitizer
   )
 

--- a/src/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/export.py
@@ -62,6 +62,10 @@ def validate(rabbitmq_host, rabbitmq_user, rabbitmq_pass, s3, s3_bucket):
       "The following environment variables must be specified: " +
       "RABBITMQ_HOST, RABBITMQ_USER, RABBITMQ_PASS"
     )
+  if not hostname_agrees_with_artsy_environment(rabbitmq_host, artsy_env):
+    raise Exception(
+      f'Hostname {rabbitmq_host} does not agree with environment {artsy_env}'
+    )
   if s3 and not s3_bucket:
     raise Exception(
       "RABBITMQ_BACKUP_S3_BUCKET must be specified in the environment."

--- a/src/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/export.py
@@ -5,7 +5,7 @@ import os
 import rabbitmq_export.context
 
 from lib.logging import setup_logging
-from lib.util import is_artsy_s3_bucket
+from lib.validations import is_artsy_s3_bucket
 
 from rabbitmq_export.export import (
   export_and_backup

--- a/src/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/export.py
@@ -5,6 +5,7 @@ import os
 import rabbitmq_export.context
 
 from lib.logging import setup_logging
+from lib.validations import hostname_agrees_with_artsy_environment
 
 from rabbitmq_export.export import (
   export_and_backup

--- a/src/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/export.py
@@ -5,7 +5,6 @@ import os
 import rabbitmq_export.context
 
 from lib.logging import setup_logging
-from lib.validations import is_artsy_s3_bucket
 
 from rabbitmq_export.export import (
   export_and_backup
@@ -70,8 +69,6 @@ def validate(rabbitmq_host, rabbitmq_user, rabbitmq_pass, s3, s3_bucket):
     raise Exception(
       "RABBITMQ_BACKUP_S3_BUCKET must be specified in the environment."
     )
-  if s3 and not is_artsy_s3_bucket(s3_bucket):
-    raise Exception(f"{s3_bucket} seems not an Artsy S3 bucket.")
 
 
 if __name__ == "__main__":

--- a/src/rabbitmq_export/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/rabbitmq_export/export.py
@@ -8,6 +8,7 @@ from distutils.dir_util import mkpath
 import rabbitmq_export.context
 
 from lib.artsy_s3_backup import ArtsyS3Backup
+from lib.util import write_file
 
 
 def export_and_backup(
@@ -70,5 +71,4 @@ def export_broker_definition(
   logging.info(
     f"Saving RabbitMQ broker definitions to {output_file} ..."
   )
-  with open(output_file, 'w') as f:
-    f.write(resp.text)
+  write_file(output_file, resp.text)

--- a/src/rabbitmq_export/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/rabbitmq_export/export.py
@@ -4,7 +4,7 @@ import requests
 
 import rabbitmq_export.context
 
-from lib.util import (
+from lib.export_backup import (
   backup_to_s3,
   setup_local_export_dir,
   write_file

--- a/src/rabbitmq_export/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/rabbitmq_export/export.py
@@ -1,14 +1,15 @@
 import logging
 import os
 import requests
-import shutil
 
 from distutils.dir_util import mkpath
 
 import rabbitmq_export.context
 
-from lib.artsy_s3_backup import ArtsyS3Backup
-from lib.util import write_file
+from lib.util import (
+  backup_to_s3,
+  write_file
+)
 
 
 def export_and_backup(
@@ -30,21 +31,15 @@ def export_and_backup(
     output_file, rabbitmq_host, rabbitmq_user, rabbitmq_pass
   )
   if s3:
-    try:
-      artsy_s3_backup = ArtsyS3Backup(
-        s3_bucket,
-        s3_prefix,
-        'rabbitmq',
-        artsy_env,
-        'json'
-      )
-      logging.info('Backing up to S3...')
-      artsy_s3_backup.backup(output_file)
-    except:
-      raise
-    finally:
-      logging.info(f"Deleting {export_dir} ...")
-      shutil.rmtree(export_dir)
+    backup_to_s3(
+      s3_bucket,
+      s3_prefix,
+      'rabbitmq',
+      artsy_env,
+      'json'
+      output_file,
+      export_dir
+    )
   else:
     logging.info(
       "Skipping backup to S3. Please delete the local files when done!"

--- a/src/rabbitmq_export/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/rabbitmq_export/export.py
@@ -2,8 +2,6 @@ import logging
 import os
 import requests
 
-from distutils.dir_util import mkpath
-
 import rabbitmq_export.context
 
 from lib.util import (
@@ -22,10 +20,10 @@ def export_and_backup(
   s3_bucket,
   s3_prefix
 ):
-  export_dir = os.path.join(local_dir, artsy_env)
-  mkpath(export_dir)
-  file_name = f"{rabbitmq_host}.json"
-  output_file = os.path.join(export_dir, file_name)
+  suffix = 'json'
+  export_dir, output_file = setup_local_export_dir(
+    local_dir, artsy_env, rabbitmq_host, suffix
+  )
   logging.info('Exporting broker definitions...')
   export_broker_definition(
     output_file, rabbitmq_host, rabbitmq_user, rabbitmq_pass
@@ -36,7 +34,7 @@ def export_and_backup(
       s3_prefix,
       'rabbitmq',
       artsy_env,
-      'json'
+      suffix,
       output_file,
       export_dir
     )

--- a/src/rabbitmq_export/rabbitmq_export/export.py
+++ b/src/rabbitmq_export/rabbitmq_export/export.py
@@ -6,6 +6,7 @@ import rabbitmq_export.context
 
 from lib.util import (
   backup_to_s3,
+  setup_local_export_dir,
   write_file
 )
 

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -41,6 +41,7 @@ def parse_env():
   ''' parse env vars '''
   vault_host = os.environ.get('VAULT_HOST')
   vault_port = os.environ.get('VAULT_PORT')
+  vault_role = os.environ.get('VAULT_ROLE')
   s3_bucket = os.environ.get('VAULT_BACKUP_S3_BUCKET', '')
   s3_prefix = os.environ.get('VAULT_BACKUP_S3_PREFIX', 'dev')
   # local dir to store snapshot
@@ -51,17 +52,19 @@ def parse_env():
     local_dir,
     vault_host,
     vault_port,
+    vault_role,
     s3_bucket,
     s3_prefix
   )
 
-def validate(artsy_env, vault_host, vault_port, s3, s3_bucket):
+def validate(artsy_env, vault_host, vault_port, vault_role, s3, s3_bucket):
   ''' validate config obtained from env and command line '''
-  if not (vault_host and vault_port):
+  if not (vault_host and vault_port and vault_role):
     raise Exception(
       "The following environment variables must be specified: " +
       "VAULT_HOST, " +
-      "VAULT_PORT"
+      "VAULT_PORT, " +
+      "VAULT_ROLE"
     )
   if not hostname_agrees_with_artsy_environment(vault_host, artsy_env):
     raise Exception(
@@ -88,6 +91,7 @@ if __name__ == "__main__":
     local_dir,
     vault_host,
     vault_port,
+    vault_role,
     s3_bucket,
     s3_prefix
   ) = parse_env()
@@ -96,6 +100,7 @@ if __name__ == "__main__":
     artsy_env,
     vault_host,
     vault_port,
+    vault_role,
     s3,
     s3_bucket
   )
@@ -105,6 +110,7 @@ if __name__ == "__main__":
     artsy_env,
     vault_host,
     vault_port,
+    vault_role,
     s3,
     s3_bucket,
     s3_prefix

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -56,23 +56,23 @@ def parse_env():
 def validate(artsy_env, vault_host, vault_port, s3, s3_bucket):
   ''' validate config obtained from env and command line '''
 
-  # make sure Vault address matches environment
-  # in case user specifies 'staging' on the command line
-  # yet supplies production Vault address in Env (and connects to Prod VPN)
-  # or the other way around
-  # address for staging is expected to contain 'stg'
-  # that for prod contain 'prd'
-  if artsy_env == 'staging':
-    assert 'stg' in vault_host
-  else:
-    assert 'prd' in vault_host
-
   if not (vault_host and vault_port):
     raise Exception(
       "The following environment variables must be specified: " +
-      "VAULT_ADDR" +
+      "VAULT_HOST, " +
       "VAULT_PORT"
     )
+
+  # make sure Vault hostname matches environment
+  # in case user specifies 'staging' on the command line
+  # yet supplies production Vault host in Env (and connects to Prod VPN)
+  # or the other way around
+  # address for staging is expected to contain 'stg'
+  # that for prod contain 'prd'
+  if artsy_env == 'staging' and not 'stg' in vault_host:
+    raise Exception(f'Vault hostname does not contain "stg": {vault_host}')
+  elif artsy_env == 'production' and not 'prd' in vault_host:
+    raise Exception(f'Vault hostname does not contain "prd": {vault_host}')
 
   if s3 and not s3_bucket:
     raise Exception(

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -5,7 +5,10 @@ import os
 import vault_snapshot.context
 
 from lib.logging import setup_logging
-from lib.validations import is_artsy_s3_bucket
+from lib.validations import (
+  hostname_agrees_with_artsy_environment,
+  is_artsy_s3_bucket
+)
 
 from vault_snapshot.snap import (
   take_snapshot
@@ -55,25 +58,16 @@ def parse_env():
 
 def validate(artsy_env, vault_host, vault_port, s3, s3_bucket):
   ''' validate config obtained from env and command line '''
-
   if not (vault_host and vault_port):
     raise Exception(
       "The following environment variables must be specified: " +
       "VAULT_HOST, " +
       "VAULT_PORT"
     )
-
-  # make sure Vault hostname matches environment
-  # in case user specifies 'staging' on the command line
-  # yet supplies production Vault host in Env (and connects to Prod VPN)
-  # or the other way around
-  # address for staging is expected to contain 'stg'
-  # that for prod contain 'prd'
-  if artsy_env == 'staging' and not 'stg' in vault_host:
-    raise Exception(f'Vault hostname does not contain "stg": {vault_host}')
-  elif artsy_env == 'production' and not 'prd' in vault_host:
-    raise Exception(f'Vault hostname does not contain "prd": {vault_host}')
-
+  if not hostname_agrees_with_artsy_environment(vault_host, artsy_env):
+    raise Exception(
+      f'Hostname {vault_host} does not agree with environment {artsy_env}'
+    )
   if s3 and not s3_bucket:
     raise Exception(
       "VAULT_BACKUP_S3_BUCKET must be specified in the environment."

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -55,13 +55,26 @@ def parse_env():
     s3_prefix
   )
 
-def validate(vault_addr, vault_user, vault_pass, s3, s3_bucket):
+def validate(artsy_env, vault_addr, s3, s3_bucket):
   ''' validate config obtained from env and command line '''
-  if not (vault_addr and vault_user and vault_pass):
+
+  # make sure Vault address matches environment
+  # in case user specifies 'staging' on the command line
+  # yet supplies production Vault address in Env (and connects to Prod VPN)
+  # or the other way around
+  # address for staging is expected to contain 'stg'
+  # that for prod contain 'prd'
+  if artsy_env == 'staging':
+    assert 'stg' in vault_addr
+  else:
+    assert 'prd' in vault_addr
+
+  if not (vault_addr):
     raise Exception(
       "The following environment variables must be specified: " +
-      "VAULT_ADDR, VAULT_USER, VAULT_PASS"
+      "VAULT_ADDR"
     )
+
   if s3 and not s3_bucket:
     raise Exception(
       "VAULT_BACKUP_S3_BUCKET must be specified in the environment."
@@ -91,9 +104,8 @@ if __name__ == "__main__":
   ) = parse_env()
 
   validate(
+    artsy_env,
     vault_addr,
-    vault_user,
-    vault_pass,
     s3,
     s3_bucket
   )
@@ -102,8 +114,6 @@ if __name__ == "__main__":
     local_dir,
     artsy_env,
     vault_addr,
-    vault_user,
-    vault_pass,
     s3,
     s3_bucket,
     s3_prefix

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -37,9 +37,8 @@ def parse_args():
 
 def parse_env():
   ''' parse env vars '''
-  vault_addr = os.environ.get('VAULT_ADDR')
-  vault_user = os.environ.get('VAULT_USER')
-  vault_pass = os.environ.get('VAULT_PASS')
+  vault_host = os.environ.get('VAULT_HOST')
+  vault_port = os.environ.get('VAULT_PORT')
   s3_bucket = os.environ.get('VAULT_BACKUP_S3_BUCKET', '')
   s3_prefix = os.environ.get('VAULT_BACKUP_S3_PREFIX', 'dev')
   # local dir to store snapshot
@@ -48,14 +47,13 @@ def parse_env():
   )
   return (
     local_dir,
-    vault_addr,
-    vault_user,
-    vault_pass,
+    vault_host,
+    vault_port,
     s3_bucket,
     s3_prefix
   )
 
-def validate(artsy_env, vault_addr, s3, s3_bucket):
+def validate(artsy_env, vault_host, vault_port, s3, s3_bucket):
   ''' validate config obtained from env and command line '''
 
   # make sure Vault address matches environment
@@ -65,14 +63,15 @@ def validate(artsy_env, vault_addr, s3, s3_bucket):
   # address for staging is expected to contain 'stg'
   # that for prod contain 'prd'
   if artsy_env == 'staging':
-    assert 'stg' in vault_addr
+    assert 'stg' in vault_host
   else:
-    assert 'prd' in vault_addr
+    assert 'prd' in vault_host
 
-  if not (vault_addr):
+  if not (vault_host and vault_port):
     raise Exception(
       "The following environment variables must be specified: " +
-      "VAULT_ADDR"
+      "VAULT_ADDR" +
+      "VAULT_PORT"
     )
 
   if s3 and not s3_bucket:
@@ -96,16 +95,16 @@ if __name__ == "__main__":
 
   (
     local_dir,
-    vault_addr,
-    vault_user,
-    vault_pass,
+    vault_host,
+    vault_port,
     s3_bucket,
     s3_prefix
   ) = parse_env()
 
   validate(
     artsy_env,
-    vault_addr,
+    vault_host,
+    vault_port,
     s3,
     s3_bucket
   )
@@ -113,7 +112,8 @@ if __name__ == "__main__":
   take_snapshot(
     local_dir,
     artsy_env,
-    vault_addr,
+    vault_host,
+    vault_port,
     s3,
     s3_bucket,
     s3_prefix

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -6,8 +6,7 @@ import vault_snapshot.context
 
 from lib.logging import setup_logging
 from lib.validations import (
-  hostname_agrees_with_artsy_environment,
-  is_artsy_s3_bucket
+  hostname_agrees_with_artsy_environment
 )
 
 from vault_snapshot.snap import (
@@ -72,8 +71,6 @@ def validate(artsy_env, vault_host, vault_port, s3, s3_bucket):
     raise Exception(
       "VAULT_BACKUP_S3_BUCKET must be specified in the environment."
     )
-  if s3 and not is_artsy_s3_bucket(s3_bucket):
-    raise Exception(f"{s3_bucket} seems not an Artsy S3 bucket.")
 
 
 if __name__ == "__main__":

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -1,0 +1,110 @@
+import argparse
+import logging
+import os
+
+import vault_snapshot.context
+
+from lib.logging import setup_logging
+from lib.util import is_artsy_s3_bucket
+
+from vault_snapshot.snap import (
+  take_snapshot
+)
+
+
+def parse_args():
+  ''' parse command line args '''
+  parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter
+  )
+  parser.add_argument(
+    'artsy_env',
+    choices=['staging', 'production'],
+    help='the artsy environment of the Vault instance'
+  )
+  parser.add_argument(
+    '--loglevel',
+    choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+    default='INFO',
+    help='log level'
+  )
+  parser.add_argument(
+    '--s3',
+    action='store_true',
+    help='indicates to save snapshot to s3'
+  )
+  return parser.parse_args()
+
+def parse_env():
+  ''' parse env vars '''
+  vault_addr = os.environ.get('VAULT_ADDR')
+  vault_user = os.environ.get('VAULT_USER')
+  vault_pass = os.environ.get('VAULT_PASS')
+  s3_bucket = os.environ.get('VAULT_BACKUP_S3_BUCKET', '')
+  s3_prefix = os.environ.get('VAULT_BACKUP_S3_PREFIX', 'dev')
+  # local dir to store snapshot
+  local_dir = os.environ.get(
+    'LOCAL_DIR', '/tmp/vault_snapshot'
+  )
+  return (
+    local_dir,
+    vault_addr,
+    vault_user,
+    vault_pass,
+    s3_bucket,
+    s3_prefix
+  )
+
+def validate(vault_addr, vault_user, vault_pass, s3, s3_bucket):
+  ''' validate config obtained from env and command line '''
+  if not (vault_addr and vault_user and vault_pass):
+    raise Exception(
+      "The following environment variables must be specified: " +
+      "VAULT_ADDR, VAULT_USER, VAULT_PASS"
+    )
+  if s3 and not s3_bucket:
+    raise Exception(
+      "VAULT_BACKUP_S3_BUCKET must be specified in the environment."
+    )
+  if s3 and not is_artsy_s3_bucket(s3_bucket):
+    raise Exception(f"{s3_bucket} seems not an Artsy S3 bucket.")
+
+
+if __name__ == "__main__":
+
+  args = parse_args()
+  loglevel, artsy_env, s3 = (
+    args.loglevel,
+    args.artsy_env,
+    args.s3
+  )
+
+  setup_logging(eval('logging.' + loglevel))
+
+  (
+    local_dir,
+    vault_addr,
+    vault_user,
+    vault_pass,
+    s3_bucket,
+    s3_prefix
+  ) = parse_env()
+
+  validate(
+    vault_addr,
+    vault_user,
+    vault_pass,
+    s3,
+    s3_bucket
+  )
+
+  take_snapshot(
+    local_dir,
+    artsy_env,
+    vault_addr,
+    vault_user,
+    vault_pass,
+    s3,
+    s3_bucket,
+    s3_prefix
+  )

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -5,7 +5,7 @@ import os
 import vault_snapshot.context
 
 from lib.logging import setup_logging
-from lib.util import is_artsy_s3_bucket
+from lib.validations import is_artsy_s3_bucket
 
 from vault_snapshot.snap import (
   take_snapshot

--- a/src/vault_snapshot/vault_snapshot/context.py
+++ b/src/vault_snapshot/vault_snapshot/context.py
@@ -1,0 +1,8 @@
+import sys
+
+from pathlib import Path
+
+# add repo root to sys.path
+# mostly for importing modules in 'lib' dir
+path_root = Path(__file__).parents[2]
+sys.path.append(str(path_root))

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -2,8 +2,6 @@ def take_snapshot(
   local_dir,
   artsy_env,
   vault_addr,
-  vault_user,
-  vault_pass,
   s3,
   s3_bucket,
   s3_prefix

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -1,13 +1,11 @@
 import logging
 import os
-import shutil
-
 from distutils.dir_util import mkpath
 
 import vault_snapshot.context
 
-from lib.artsy_s3_backup import ArtsyS3Backup
 from lib.util import (
+  backup_to_s3,
   url_host_port
 )
 from lib.vault import Vault
@@ -34,21 +32,15 @@ def take_snapshot(
   logging.info('Taking snapshot...')
   vault_client.take_snapshot(output_file)
   if s3:
-    try:
-      artsy_s3_backup = ArtsyS3Backup(
-        s3_bucket,
-        s3_prefix,
-        'vault',
-        artsy_env,
-        'gz'
-      )
-      logging.info('Backing up to S3...')
-      artsy_s3_backup.backup(output_file)
-    except:
-      raise
-    finally:
-      logging.info(f"Deleting {export_dir} ...")
-      shutil.rmtree(export_dir)
+    backup_to_s3(
+      s3_bucket,
+      s3_prefix,
+      'vault',
+      artsy_env,
+      'gz',
+      output_file,
+      export_dir
+    )
   else:
     logging.info(
       "Skipping backup to S3. Please delete the local files when done!"

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -1,5 +1,6 @@
 import logging
 import os
+
 import vault_snapshot.context
 
 from lib.util import (
@@ -22,12 +23,15 @@ def take_snapshot(
 ):
   vault_client = Vault(
     url_host_port(vault_host, vault_port),
-    'iam',
+    auth_method='iam',
     role=vault_role
   )
   suffix = 'gz'
   export_dir, output_file = setup_local_export_dir(
-    local_dir, artsy_env, vault_host, suffix
+    local_dir,
+    artsy_env,
+    vault_host,
+    suffix
   )
   logging.info('Taking snapshot...')
   vault_client.take_snapshot(output_file)

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -1,0 +1,11 @@
+def take_snapshot(
+  local_dir,
+  artsy_env,
+  vault_addr,
+  vault_user,
+  vault_pass,
+  s3,
+  s3_bucket,
+  s3_prefix
+):
+  pass

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -12,3 +12,4 @@ def take_snapshot(
   s3_prefix
 ):
   vault_client = Vault(vault_addr, 'iam', role='opstools-role')
+  snapshot = vault_client.take_snapshot('/tmp/vault_snapshot.gz')

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -16,6 +16,7 @@ def take_snapshot(
   artsy_env,
   vault_host,
   vault_port,
+  vault_role,
   s3,
   s3_bucket,
   s3_prefix
@@ -23,7 +24,7 @@ def take_snapshot(
   vault_client = Vault(
     url_host_port(vault_host, vault_port),
     'iam',
-    role='opstools-role'
+    role=vault_role
   )
   export_dir = os.path.join(local_dir, artsy_env)
   mkpath(export_dir)

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -1,15 +1,52 @@
+import logging
+import os
+import shutil
+
+from distutils.dir_util import mkpath
+
 import vault_snapshot.context
 
+from lib.artsy_s3_backup import ArtsyS3Backup
 from lib.vault import Vault
 
 
 def take_snapshot(
   local_dir,
   artsy_env,
-  vault_addr,
+  vault_host,
+  vault_port,
   s3,
   s3_bucket,
   s3_prefix
 ):
-  vault_client = Vault(vault_addr, 'iam', role='opstools-role')
-  snapshot = vault_client.take_snapshot('/tmp/vault_snapshot.gz')
+  vault_client = Vault(
+    f'https://{vault_host}:{vault_port}',
+    'iam',
+    role='opstools-role'
+  )
+  export_dir = os.path.join(local_dir, artsy_env)
+  mkpath(export_dir)
+  file_name = f"{vault_host}.gz"
+  output_file = os.path.join(export_dir, file_name)
+  logging.info('Taking snapshot...')
+  vault_client.take_snapshot(output_file)
+  if s3:
+    try:
+      artsy_s3_backup = ArtsyS3Backup(
+        s3_bucket,
+        s3_prefix,
+        'vault',
+        artsy_env,
+        'gz'
+      )
+      logging.info('Backing up to S3...')
+      artsy_s3_backup.backup(output_file)
+    except:
+      raise
+    finally:
+      logging.info(f"Deleting {export_dir} ...")
+      shutil.rmtree(export_dir)
+  else:
+    logging.info(
+      "Skipping backup to S3. Please delete the local files when done!"
+    )

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -11,4 +11,4 @@ def take_snapshot(
   s3_bucket,
   s3_prefix
 ):
-  vault_client = Vault(vault_addr, 'iam')
+  vault_client = Vault(vault_addr, 'iam', role='opstools-role')

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -7,6 +7,9 @@ from distutils.dir_util import mkpath
 import vault_snapshot.context
 
 from lib.artsy_s3_backup import ArtsyS3Backup
+from lib.util import (
+  url_host_port
+)
 from lib.vault import Vault
 
 
@@ -20,7 +23,7 @@ def take_snapshot(
   s3_prefix
 ):
   vault_client = Vault(
-    f'https://{vault_host}:{vault_port}',
+    url_host_port(vault_host, vault_port),
     'iam',
     role='opstools-role'
   )

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -3,11 +3,11 @@ import os
 
 import vault_snapshot.context
 
-from lib.util import (
+from lib.export_backup import (
   backup_to_s3,
-  setup_local_export_dir,
-  url_host_port
+  setup_local_export_dir
 )
+from lib.util import url_host_port
 from lib.vault import Vault
 
 

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -1,11 +1,10 @@
 import logging
 import os
-from distutils.dir_util import mkpath
-
 import vault_snapshot.context
 
 from lib.util import (
   backup_to_s3,
+  setup_local_export_dir,
   url_host_port
 )
 from lib.vault import Vault
@@ -26,10 +25,10 @@ def take_snapshot(
     'iam',
     role=vault_role
   )
-  export_dir = os.path.join(local_dir, artsy_env)
-  mkpath(export_dir)
-  file_name = f"{vault_host}.gz"
-  output_file = os.path.join(export_dir, file_name)
+  suffix = 'gz'
+  export_dir, output_file = setup_local_export_dir(
+    local_dir, artsy_env, vault_host, suffix
+  )
   logging.info('Taking snapshot...')
   vault_client.take_snapshot(output_file)
   if s3:
@@ -38,7 +37,7 @@ def take_snapshot(
       s3_prefix,
       'vault',
       artsy_env,
-      'gz',
+      suffix,
       output_file,
       export_dir
     )

--- a/src/vault_snapshot/vault_snapshot/snap.py
+++ b/src/vault_snapshot/vault_snapshot/snap.py
@@ -1,3 +1,8 @@
+import vault_snapshot.context
+
+from lib.vault import Vault
+
+
 def take_snapshot(
   local_dir,
   artsy_env,
@@ -6,4 +11,4 @@ def take_snapshot(
   s3_bucket,
   s3_prefix
 ):
-  pass
+  vault_client = Vault(vault_addr, 'iam')


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR supports [PHIRE-407]

### Description

Backup Vault data to S3 daily. And refactoring.

- Add vault_snapshot script/cronjob which does the Vault backup.
- Update src/lib/vault.py:
  - Support IAM login.
  - Add take_snapshot method.
- Move sanitizers and validators out of src/lib/util.py lib as it's becoming too long.
- Introduce src/lib/export_backup.py which absorbs s3 upload logic and local file logic from the scripts.
- Split migrate_config_secrets script's VAULT_ADDR env var into host and port vars.
- And misc. improvements.

dev/staging/production env has been updated.

Merging requires the following PRs to be merged first:

- [Related IAM changes.](https://github.com/artsy/infrastructure/pull/641)
- [Related DNS and Kubernetes changes.](https://github.com/artsy/substance/pull/368)

[PHIRE-407]: https://artsyproduct.atlassian.net/browse/PHIRE-407?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ