### PR TITLE
feat: let vault role be optional

### DIFF
--- a/src/lib/vault.py
+++ b/src/lib/vault.py
@@ -34,18 +34,24 @@ class Vault:
     else:
       raise Exception(f'Un-supported auth method: {auth_method}')
 
-  def _iam_login(self, role):
+  def _iam_login(self, role=None):
     ''' log into Vault using AWS IAM keys '''
-    if role == None:
-      raise Exception(f'No Vault role specified for IAM auth method.')
     session = boto3.Session()
     credentials = session.get_credentials()
-    self._client.auth.aws.iam_login(
-      credentials.access_key,
-      credentials.secret_key,
-      credentials.token,
-      role=role
-    )
+    if role == None:
+      # role not specified, let hvac default role to same as iam username
+      self._client.auth.aws.iam_login(
+        credentials.access_key,
+        credentials.secret_key,
+        credentials.token,
+      )
+    else:
+      self._client.auth.aws.iam_login(
+        credentials.access_key,
+        credentials.secret_key,
+        credentials.token,
+        role=role
+      )
 
   def get(self, key):
     ''' get an entry '''

--- a/src/vault_snapshot/snap.py
+++ b/src/vault_snapshot/snap.py
@@ -57,14 +57,13 @@ def parse_env():
     s3_prefix
   )
 
-def validate(artsy_env, vault_host, vault_port, vault_role, s3, s3_bucket):
+def validate(artsy_env, vault_host, vault_port, s3, s3_bucket):
   ''' validate config obtained from env and command line '''
-  if not (vault_host and vault_port and vault_role):
+  if not (vault_host and vault_port):
     raise Exception(
       "The following environment variables must be specified: " +
       "VAULT_HOST, " +
-      "VAULT_PORT, " +
-      "VAULT_ROLE"
+      "VAULT_PORT"
     )
   if not hostname_agrees_with_artsy_environment(vault_host, artsy_env):
     raise Exception(
@@ -100,7 +99,6 @@ if __name__ == "__main__":
     artsy_env,
     vault_host,
     vault_port,
-    vault_role,
     s3,
     s3_bucket
   )


### PR DESCRIPTION
The type of this PR is: **Feat**

Follows https://github.com/artsy/infrastructure/pull/654

### Description

That infra PR adds `opstools` Vault role, which matches the IAM username that Opstools scripts run under. So we can just let HVAC lib assume that the role name is same as IAM username. Therefore, make VAULT_ROLE optional.

### Migration (done)
---

hokusai staging env unset VAULT_ROLE
hokusai production env unset VAULT_ROLE

delete VAULT_ROLE from .env.shared and update S3.