### PR TITLE
feat: bump kubectl to match k8s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN pip --no-cache-dir install poetry
 RUN pip --no-cache-dir install awscli --upgrade
 
 ARG terraform_version=0.12.31
-ARG kubectl_version=1.20.15
+ARG kubectl_version=1.21.14
 
 RUN apk --no-cache --quiet add \
   curl \


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PHIRE-571]

### Description

Kubernets clusters are now at v1.21.14. Bump kubectl to match.

[PHIRE-571]: https://artsyproduct.atlassian.net/browse/PHIRE-571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ