### PR TITLE
chore: regenerate and upgrade .secrets.baseline

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -27,6 +27,9 @@
       "name": "GitHubTokenDetector"
     },
     {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -35,6 +38,9 @@
     },
     {
       "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -50,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -66,6 +78,9 @@
     },
     {
       "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
     },
     {
       "name": "TwilioKeyDetector"
@@ -131,5 +146,5 @@
       }
     ]
   },
-  "generated_at": "2023-11-29T20:17:56Z"
+  "generated_at": "2024-05-07T20:50:36Z"
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PLATFORM-123]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description. Please be reminded to filter out sensitive information, as this is a public repository. -->

Regenerate `.secrets.baseline` file and upgrade version. Note that new plugins are added following version bump.

How:
```sh
# regenerate
detect-secrets scan > .secrets.baseline
# add baseline exclusion filter
detect-secrets scan --baseline .secrets.baseline
```


[PLATFORM-123]: https://artsyproduct.atlassian.net/browse/PLATFORM-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ