### PR TITLE
feat: write secrets as export commands

### DIFF
--- a/src/load_secrets_from_vault/load.py
+++ b/src/load_secrets_from_vault/load.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 
 import load_secrets_from_vault.context

--- a/src/load_secrets_from_vault/load_secrets_from_vault/load.py
+++ b/src/load_secrets_from_vault/load_secrets_from_vault/load.py
@@ -33,6 +33,6 @@ def load_secrets(artsy_project, vault_host, vault_port, secrets_file, kvv2_mount
     for key in keys:
       try:
         value = vault_client.get(key)
-        f.write(f'{key}={value}\n')
+        f.write(f"export {key}='{value}'\n")
       except hvac.exceptions.InvalidPath:
         logging.info(f'{key} either does not exist or is soft deleted.')


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR supports [PHIRE-1097]
Related to https://github.com/artsy/hokusai-sandbox/pull/74

### Description

Currently, the secrets file is written in this format:

```
FOO=bar
BAR=foo
```

A client that wants to export the vars into Shell environment must do something like this:

```
export $(cat /secrets/secrets | xargs)
```

This PR changes the output format to:

```
export FOO='bar'
export BAR='foo'
```

The changes are:
- The content becomes `export` commands.
- Values are single quoted.

This allows the client to simply do:

```
source /secrets/secrets
```


[PHIRE-1097]: https://artsyproduct.atlassian.net/browse/PHIRE-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ