### PR TITLE
feat: update secret migration script

### DIFF
--- a/src/lib/hokusai.py
+++ b/src/lib/hokusai.py
@@ -3,8 +3,7 @@ import logging
 from lib.util import run_cmd
 
 
-def env_unset(project_dir, env, var_names):
-  ''' run hokusai env unset for vars for project '''
-  for var in var_names:
-    logging.debug(f'unsetting {var}...')
-    run_cmd(f'hokusai {env} env unset {var}', project_dir)
+def env_unset(project_dir, env, var):
+  ''' run hokusai env unset for var for project '''
+  logging.debug(f'unsetting {var}...')
+  run_cmd(f'hokusai {env} env unset {var}', project_dir)

--- a/src/lib/test/test_hokusai.py
+++ b/src/lib/test/test_hokusai.py
@@ -12,11 +12,6 @@ def describe_env_unset():
         'hokusai fooenv env unset foo',
         'foodir'
       ),
-      mocker.call(
-        'hokusai fooenv env unset bar',
-        'foodir'
-      )
     ]
-    env_unset('foodir', 'fooenv', ['foo', 'bar'])
-    assert spy.call_count == 2
+    env_unset('foodir', 'fooenv', 'foo')
     spy.assert_has_calls(calls, any_order=True)

--- a/src/lib/test/test_vault.py
+++ b/src/lib/test/test_vault.py
@@ -13,11 +13,10 @@ def describe_vault():
     def it_inits(mocker):
       mocker.patch('lib.vault.boto3')
       mocker.patch('lib.vault.hvac.Client')
-      obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', 'foosanitizer')
+      obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
       assert obj._client is lib.vault.hvac.Client()
       assert obj._mount_point == 'foomountpoint'
       assert obj._path == 'foopath'
-      assert obj._sanitizer == 'foosanitizer'
       assert obj._client.token == 'footoken'
 
   def describe_login():
@@ -80,14 +79,14 @@ def describe_vault():
       def it_raises(mocker, mock_hvac_client_class):
         mocker.patch('lib.vault.boto3')
         mocker.patch('lib.vault.hvac.Client').side_effect = mock_hvac_client_class
-        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', 'foosanitizer')
+        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
         with pytest.raises(KeyError):
           obj.get('barkey')
     def describe_key_exists():
       def it_gets(mocker):
         mocker.patch('lib.vault.boto3')
         mocker.patch('lib.vault.hvac.Client')
-        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', 'foosanitizer')
+        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
         spy = mocker.spy(obj._client.secrets.kv, 'read_secret_version')
         assert obj.get('fookey') == lib.vault.hvac.Client().secrets.kv.read_secret_version()['data']['data']['key']
         spy.assert_has_calls([
@@ -102,7 +101,7 @@ def describe_vault():
       def it_sets(mocker, mock_exception_function):
         mocker.patch('lib.vault.boto3')
         mocker.patch('lib.vault.hvac.Client')
-        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', 'foosanitizer')
+        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
         mocker.patch.object(obj, 'get').side_effect = mock_exception_function
         mocker.patch.object(obj, 'set')
         spy = mocker.spy(obj, 'set')
@@ -114,9 +113,7 @@ def describe_vault():
       def it_sets(mocker):
         mocker.patch('lib.vault.boto3')
         mocker.patch('lib.vault.hvac.Client')
-        def foosanitizer(value):
-          pass
-        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', foosanitizer)
+        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
         mocker.patch.object(obj, 'get', return_value='barvalue')
         mocker.patch.object(obj, 'set')
         spy = mocker.spy(obj, 'set')
@@ -128,9 +125,7 @@ def describe_vault():
       def it_skips(mocker):
         mocker.patch('lib.vault.boto3')
         mocker.patch('lib.vault.hvac.Client')
-        def foosanitizer(value):
-          return value
-        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', foosanitizer)
+        obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
         mocker.patch.object(obj, 'get', return_value='foovalue')
         mocker.patch.object(obj, 'set')
         spy = mocker.spy(obj, 'set')
@@ -141,7 +136,7 @@ def describe_vault():
     def it_lists(mocker):
       mocker.patch('lib.vault.boto3')
       mocker.patch('lib.vault.hvac.Client')
-      obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', 'foosanitizer')
+      obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
       spy = mocker.spy(obj._client.secrets.kv.v2, 'list_secrets')
       assert obj.list() == lib.vault.hvac.Client().secrets.kv.v2.list_secrets()
       spy.assert_has_calls([
@@ -155,9 +150,7 @@ def describe_vault():
     def it_sets(mocker):
       mocker.patch('lib.vault.boto3')
       mocker.patch('lib.vault.hvac.Client')
-      def foosanitizer(value):
-        return value
-      obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', foosanitizer)
+      obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
       spy = mocker.spy(obj._client.secrets.kv.v2, 'create_or_update_secret')
       obj.set('fookey', 'foovalue')
       spy.assert_has_calls([
@@ -170,9 +163,7 @@ def describe_vault():
     def it_does_not_set_when_dry_run(mocker):
       mocker.patch('lib.vault.boto3')
       mocker.patch('lib.vault.hvac.Client')
-      def foosanitizer(value):
-        return value
-      obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath', foosanitizer)
+      obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
       spy = mocker.spy(obj._client.secrets.kv.v2, 'create_or_update_secret')
       obj.set('fookey', 'foovalue', True)
       assert spy.call_count == 0

--- a/src/lib/util.py
+++ b/src/lib/util.py
@@ -38,9 +38,9 @@ def list_subtract(list_a, *args):
 def match_or_raise(str1, str2):
   ''' raise if str1 and str2 differ '''
   if str1 == str2:
-    logging.debug('str1 and str2 match')
+    logging.info('str1 and str2 match')
   else:
-    logging.error('str1 and str2 different')
+    logging.info('str1 and str2 different')
     raise
 
 def parse_string_of_key_value_pairs(str1):

--- a/src/lib/vault.py
+++ b/src/lib/vault.py
@@ -16,15 +16,11 @@ class Vault:
     token=None,
     role=None,
     kvv2_mount_point=None,
-    path=None,
-    sanitizer=None
+    path=None
   ):
     self._client = hvac.Client(url=addr)
     self._mount_point = kvv2_mount_point
     self._path = path
-    # a function for sanitizing a value before setting it in Vault
-    # this is org-specific
-    self._sanitizer = sanitizer
     self._login(auth_method, token, role)
 
   def _login(self, auth_method, token=None, role=None):
@@ -87,7 +83,7 @@ class Vault:
       return
 
     # no exception means there's some value
-    if current_value == self._sanitizer(value):
+    if current_value == value:
       logging.debug(
         f'{key} already has the value. Nothing to do.'
       )
@@ -107,9 +103,8 @@ class Vault:
   def set(self, key, value, dry_run=False):
     ''' set an entry '''
     full_path = f'{self._path}{key}'
-    cleaned_value = self._sanitizer(value)
     logging.debug(f'Vault: setting {full_path}')
-    entry = { key: cleaned_value}
+    entry = { key: value}
     if dry_run:
       logging.info(f'Would have set {full_path}')
     else:

--- a/src/migrate_config_secrets/migrate_config_secrets/migrate.py
+++ b/src/migrate_config_secrets/migrate_config_secrets/migrate.py
@@ -6,15 +6,10 @@ import migrate_config_secrets.context
 
 from lib.hokusai import env_unset
 from lib.k8s_configmap import ConfigMap
-from lib.k8s_secret import K8sSecret
 from lib.kctl import Kctl
 from lib.util import (
   match_or_raise,
   url_host_port
-)
-from lib.sanitizers import (
-  config_secret_sanitizer,
-  config_secret_sanitizer_artsy
 )
 from lib.vault import Vault
 
@@ -28,16 +23,11 @@ def ask_user_to_identify_sensitive_vars(keys_values):
       sensitive += [k]
   return sensitive
 
-def compare_k8s_secret_configmap(secret_obj, configmap_obj, sensitive_vars):
-  ''' compare k8s secret and configmap, var by var '''
-  for var in sensitive_vars:
-    logging.debug(f'Comparing {var} ...')
-    k8s_secret_value = secret_obj.get(var)
-    configmap_value = configmap_obj.get(var)
-    match_or_raise(
-      k8s_secret_value,
-      config_secret_sanitizer_artsy(configmap_value)
-    )
+def compare_vault_configmap(vault_client, configmap_obj, var):
+  ''' raise if Vault and Configmap values for var different '''
+  configmap_value = configmap_obj.get(var)
+  vault_value = vault_client.get(var)
+  match_or_raise(vault_value, configmap_value)
 
 def get_sensitive_vars(configmap_obj, artsy_project, artsy_env):
   configmap_vars = configmap_obj.load()
@@ -62,23 +52,21 @@ def migrate_config_secrets(
   dry_run
 ):
   ''' migrate sensitive configs from configmap to Vault '''
-  kctl = Kctl(False, artsy_env)
+  in_cluster = False
+  kctl = Kctl(in_cluster, artsy_env)
   configmap_name = f'{artsy_project}-environment'
   configmap_obj = ConfigMap(kctl, configmap_name)
-
-  secret_obj = K8sSecret(kctl, artsy_project)
-  path = 'kubernetes/apps/' + f'{artsy_project}/'
+  vault_path = 'kubernetes/apps/' + f'{artsy_project}/'
 
   logging.info(
-    f'Migrating sensitive configs from {artsy_env} {configmap_name} configmap to {path} in Vault...'
+    f'Migrating sensitive configs from {artsy_env} {configmap_name} configmap to {vault_path} in Vault...'
   )
 
   vault_client = Vault(
     url_host_port(vault_host, vault_port),
     auth_method='iam',
     kvv2_mount_point=kvv2_mount_point,
-    path=path,
-    sanitizer=config_secret_sanitizer
+    path=vault_path,
   )
 
   logging.info('Getting list of sensitive vars...')
@@ -92,55 +80,22 @@ def migrate_config_secrets(
       configmap_obj, artsy_project, artsy_env
     )
 
-  logging.info('Configuring vars in Vault...')
-  update_vault(vault_client, configmap_obj, sensitive_vars, dry_run)
+  if not dry_run:
+    logging.info('Moving vars from ConfigMap to Vault...')
+    move_vars(vault_client, configmap_obj, sensitive_vars, repos_base_dir, artsy_project, artsy_env)
 
-  if dry_run:
-    logging.info('Skipping the rest because this is a dry run.')
-  else:
-    logging.info('Syncing vars from Vault to k8s secret...')
-    sync_vault_k8s_secret(
-      kctl, vault_client, secret_obj, artsy_project, sensitive_vars
-    )
-
-    logging.info('Comparing k8s secret with configmap...')
-    compare_k8s_secret_configmap(secret_obj, configmap_obj, sensitive_vars)
-
-    logging.info('Deleting vars from configmap...')
-    project_repo_dir = os.path.join(repos_base_dir, artsy_project)
-    env_unset(project_repo_dir, artsy_env, sensitive_vars)
-
-def sync_vault_k8s_secret(
-  kctl,
-  vault_client,
-  secret_obj,
-  artsy_project,
-  sensitive_vars
-):
-  logging.info('Force sync Vault -> k8s secret...')
-  epoch_time = int(time.time())
-  kctl.annotate(
-    'externalsecret', artsy_project, f'force-sync={epoch_time}'
-  )
-  # allow annotate to finish
-  time.sleep(10)
-
-  # confirm the two are in sync, var by var
-  logging.info(
-    'Comparing values in Vault with values in k8s secret...'
-  )
-  for var in sensitive_vars:
-    logging.debug(f'Comparing {var} ...')
-    vault_value = vault_client.get(var)
-    k8s_secret_value = secret_obj.get(var)
-    match_or_raise(
-      vault_value,
-      config_secret_sanitizer(k8s_secret_value)
-    )
-
-def update_vault(vault_client, configmap_obj, var_names, dry_run):
+def move_vars(vault_client, configmap_obj, var_names, repos_base_dir, artsy_project, artsy_env):
   ''' configure vars in Vault '''
+  project_repo_dir = os.path.join(repos_base_dir, artsy_project)
   for var in var_names:
-    logging.debug(f'Updating {var} value in Vault...')
+    logging.info(f'Moving {var} from ConfigMap to Vault...')
     configmap_value = configmap_obj.get(var)
-    vault_client.get_set(var, configmap_value, dry_run)
+    vault_client.get_set(var, configmap_value)
+    logging.info('Checking if Vault and configmap have same value...')
+    compare_vault_configmap(vault_client, configmap_obj, var)
+    logging.info('Same value.')
+    # ask user about deleting var in configmap
+    answer = input(f'would you like to delete {var} from configmap (y/n)? ')
+    if answer == 'y':
+      logging.info(f'Deleting {var} from configmap...')
+      env_unset(project_repo_dir, artsy_env, var)

--- a/src/migrate_config_secrets/migrate_config_secrets/migrate.py
+++ b/src/migrate_config_secrets/migrate_config_secrets/migrate.py
@@ -93,7 +93,6 @@ def move_vars(vault_client, configmap_obj, var_names, repos_base_dir, artsy_proj
     vault_client.get_set(var, configmap_value)
     logging.info('Checking if Vault and configmap have same value...')
     compare_vault_configmap(vault_client, configmap_obj, var)
-    logging.info('Same value.')
     # ask user about deleting var in configmap
     answer = input(f'would you like to delete {var} from configmap (y/n)? ')
     if answer == 'y':


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR supports [PHIRE-1095]

### Description

This script is for migrating a Kubernetes app's secrets from ConfigMap to Vault. It requires updating because on Kubernetes side we switched the integration from ExternalSecretsOperator (ESO) to custom script. Much of the code removed here are for ESO.

Example of running script on hokusai-sandbox project:
```
foreman run --env .env.shared,.env python src/migrate_config_secrets/migrate.py staging hokusai-sandbox ~/code
```

[PHIRE-1095]: https://artsyproduct.atlassian.net/browse/PHIRE-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ