### PR TITLE
fix: .env.example being ignored

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-!.env.example
 *.egg
 *.egg-info/
 *.log
@@ -28,6 +27,7 @@
 .coverage
 .env
 .env.*
+!.env.example
 .env/
 .hokusai-tmp
 .idea


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

While working in Fortress repo, I found that the following order in `.gitignore` file actually ignores `.env.example`:

```
!.env.example
.env.*
```

While the following gives what's desired - make the file eligible to be checked in:

```
.env*
!.env.example
```