### PR TITLE
feat: let docker ignore txt files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,6 +8,7 @@
 **/*.so
 **/*.spec
 **/*.swp
+**/*.txt
 **/*.yaml
 **/*.yml
 **/*/*.py[cod]


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Realizing that `.txt` files are included in docker image. Let's exclude them because they shouldn't be required for code execution.

```
# on main branch
artsy-2:opstools jxu$ ls *.txt
foo.txt                           
artsy-2:opstools jxu$ hokusai build              
#1 [internal] load build definition from Dockerfile
...
#18 DONE 0.1s
artsy-2:opstools jxu$ docker run -it hokusai_opstools sh             
/src $ ls *.txt
foo.txt
```