### PR TITLE
feat: script to set expires_at meta for JWTs in Vault

### DIFF
--- a/src/lib/test/test_vault.py
+++ b/src/lib/test/test_vault.py
@@ -138,7 +138,7 @@ def describe_vault():
       mocker.patch('lib.vault.hvac.Client')
       obj = Vault('fooaddr', 'token', 'footoken', None, 'foomountpoint', 'foopath')
       spy = mocker.spy(obj._client.secrets.kv.v2, 'list_secrets')
-      assert obj.list() == lib.vault.hvac.Client().secrets.kv.v2.list_secrets()
+      assert obj.list(only_valid=False) == lib.vault.hvac.Client().secrets.kv.v2.list_secrets()['data']['keys']
       spy.assert_has_calls([
         mocker.call(
           path='foopath',

--- a/src/load_secrets_from_vault/load_secrets_from_vault/load.py
+++ b/src/load_secrets_from_vault/load_secrets_from_vault/load.py
@@ -13,9 +13,7 @@ from lib.vault import Vault
 def load_secrets(artsy_project, vault_host, vault_port, secrets_file, kvv2_mount_point):
   ''' load secrets from  Vault and write them to a file '''
   logging.debug(f'Loading secrets from {vault_host}:{vault_port} under {kvv2_mount_point}')
-
   path = f'kubernetes/apps/{artsy_project}/'
-
   vault_client = Vault(
     url_host_port(vault_host, vault_port),
     auth_method='kubernetes',
@@ -24,15 +22,9 @@ def load_secrets(artsy_project, vault_host, vault_port, secrets_file, kvv2_mount
     kvv2_mount_point=kvv2_mount_point,
     path=path,
   )
-
-  keys = vault_client.list()['data']['keys']
-
+  keys = vault_client.list()
   logging.debug(f'fetched keys from Vault: {keys}')
-
   with open(secrets_file, 'w') as f:
     for key in keys:
-      try:
-        value = vault_client.get(key)
-        f.write(f"export {key}='{value}'\n")
-      except hvac.exceptions.InvalidPath:
-        logging.debug(f'{key} either does not exist or is soft deleted.')
+      value = vault_client.get(key)
+      f.write(f"export {key}='{value}'\n")

--- a/src/set_vault_jwt_expiration/set.py
+++ b/src/set_vault_jwt_expiration/set.py
@@ -27,11 +27,6 @@ def parse_args():
     help='artsy project'
   )
   parser.add_argument(
-    '--dry-run',
-    action="store_true",
-    help=("Dry Run. Won't make any changes.")
-  )
-  parser.add_argument(
     '--loglevel',
     choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
     default='INFO',
@@ -63,10 +58,9 @@ def validate(artsy_env, vault_host, vault_port):
 if __name__ == "__main__":
 
   args = parse_args()
-  artsy_env, artsy_project, dry_run, loglevel = (
+  artsy_env, artsy_project, loglevel = (
     args.artsy_env,
     args.artsy_project,
-    args.dry_run,
     args.loglevel,
   )
   setup_logging(eval('logging.' + loglevel))
@@ -78,5 +72,4 @@ if __name__ == "__main__":
     vault_host,
     vault_port,
     kvv2_mount_point,
-    dry_run
   )

--- a/src/set_vault_jwt_expiration/set.py
+++ b/src/set_vault_jwt_expiration/set.py
@@ -1,0 +1,82 @@
+import argparse
+import logging
+import os
+
+import set_vault_jwt_expiration.context
+
+from set_vault_jwt_expiration.set import set_jwt_expiration
+from lib.logging import setup_logging
+from lib.validations import (
+  hostname_agrees_with_artsy_environment
+)
+
+
+def parse_args():
+  ''' parse command line args '''
+  parser = argparse.ArgumentParser(
+    formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    description=('Set expires_at meta for JWTs')
+  )
+  parser.add_argument(
+    'artsy_env',
+    choices=['staging', 'production'],
+    help='artsy environment'
+  )
+  parser.add_argument(
+    'artsy_project',
+    help='artsy project'
+  )
+  parser.add_argument(
+    '--dry-run',
+    action="store_true",
+    help=("Dry Run. Won't make any changes.")
+  )
+  parser.add_argument(
+    '--loglevel',
+    choices=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
+    default='INFO',
+    help='log level'
+  )
+  return parser.parse_args()
+
+def parse_env():
+  ''' parse env vars '''
+  vault_host = os.environ.get('VAULT_HOST')
+  vault_port = os.environ.get('VAULT_PORT')
+  kvv2_mount_point = os.environ.get('VAULT_KVV2_MOUNT_POINT')
+  return vault_host, vault_port, kvv2_mount_point
+
+def validate(artsy_env, vault_host, vault_port):
+  ''' validate config obtained from env and command line '''
+  if not (vault_host and vault_port):
+    raise Exception(
+      "The following environment variables must be specified: " +
+      "VAULT_HOST, " +
+      "VAULT_PORT"
+    )
+  if not hostname_agrees_with_artsy_environment(vault_host, artsy_env):
+    raise Exception(
+      f'Hostname {vault_host} does not agree with environment {artsy_env}'
+    )
+
+
+if __name__ == "__main__":
+
+  args = parse_args()
+  artsy_env, artsy_project, dry_run, loglevel = (
+    args.artsy_env,
+    args.artsy_project,
+    args.dry_run,
+    args.loglevel,
+  )
+  setup_logging(eval('logging.' + loglevel))
+  vault_host, vault_port, kvv2_mount_point = parse_env()
+  validate(artsy_env, vault_host, vault_port)
+  set_jwt_expiration(
+    artsy_env,
+    artsy_project,
+    vault_host,
+    vault_port,
+    kvv2_mount_point,
+    dry_run
+  )

--- a/src/set_vault_jwt_expiration/set_vault_jwt_expiration/context.py
+++ b/src/set_vault_jwt_expiration/set_vault_jwt_expiration/context.py
@@ -1,0 +1,6 @@
+import sys
+
+from pathlib import Path
+
+path_root = Path(__file__).parents[2]
+sys.path.append(str(path_root))

--- a/src/set_vault_jwt_expiration/set_vault_jwt_expiration/set.py
+++ b/src/set_vault_jwt_expiration/set_vault_jwt_expiration/set.py
@@ -18,10 +18,8 @@ def set_jwt_expiration(
   vault_host,
   vault_port,
   kvv2_mount_point,
-  dry_run
 ):
   ''' set expires_at custom header for all JWTs '''
-
   vault_path = 'kubernetes/apps/' + f'{artsy_project}/'
   vault_client = Vault(
     url_host_port(vault_host, vault_port),
@@ -29,22 +27,17 @@ def set_jwt_expiration(
     kvv2_mount_point=kvv2_mount_point,
     path=vault_path,
   )
-
   # get list of jwt vars
   jwt_vars = vault_client.list(match_function=is_jwt, match_type='value')
-  logging.debug(f'List of JWTs: {jwt_vars}')
-
+  logging.info(f'List of JWTs: {jwt_vars}')
   for var in jwt_vars:
-    jwt_string = vault_client.get(var)
-    answer = input(
-      f'would you like to set custom metadata expires_at for {var} to blah: (y/n)? '
+    logging.info(
+      f"Checking JWT {var}..."
     )
-    if answer == 'y':
-      logging.info(f'Setting...')
-      # set expires_at in their custom metadata
-      set_exp_meta(vault_client, var, jwt_string, dry_run)
+    jwt_string = vault_client.get(var)
+    set_exp_meta(vault_client, var, jwt_string)
 
-def set_exp_meta(vault_client, var, jwt_str, dry_run):
+def set_exp_meta(vault_client, var, jwt_str):
   ''' extract expiration date from jwt payload and set it in vault custom metadata '''
   exp_date_filler = 'nil'
   exp_date_meta_key = 'expires_at'
@@ -63,10 +56,9 @@ def set_exp_meta(vault_client, var, jwt_str, dry_run):
       f"JWT does not have exp payload or exp payload is not valid"
     )
     exp_date_str = exp_date_filler
-  logging.info(f"Setting custom expire_at metadata: {exp_date_str}")
-  if dry_run:
-    logging.info(
-      f"This is dry run, not going to set metdata"
-    )
-  else:
+  answer = input(
+    f'would you like to set custom metadata expires_at for {var} to {exp_date_str}: (y/n)? '
+  )
+  if answer == 'y':
+    logging.info(f'Setting...')
     vault_client.update_custom_meta(var, exp_date_meta_key, exp_date_str)

--- a/src/set_vault_jwt_expiration/set_vault_jwt_expiration/set.py
+++ b/src/set_vault_jwt_expiration/set_vault_jwt_expiration/set.py
@@ -1,0 +1,72 @@
+import logging
+
+import datetime
+import jwt
+
+import set_vault_jwt_expiration.context
+
+from lib.jwt import is_jwt
+from lib.util import (
+  url_host_port
+)
+from lib.vault import Vault
+
+
+def set_jwt_expiration(
+  artsy_env,
+  artsy_project,
+  vault_host,
+  vault_port,
+  kvv2_mount_point,
+  dry_run
+):
+  ''' set expires_at custom header for all JWTs '''
+
+  vault_path = 'kubernetes/apps/' + f'{artsy_project}/'
+  vault_client = Vault(
+    url_host_port(vault_host, vault_port),
+    auth_method='iam',
+    kvv2_mount_point=kvv2_mount_point,
+    path=vault_path,
+  )
+
+  # get list of jwt vars
+  jwt_vars = vault_client.list(match_function=is_jwt, match_type='value')
+  logging.debug(f'List of JWTs: {jwt_vars}')
+
+  for var in jwt_vars:
+    jwt_string = vault_client.get(var)
+    answer = input(
+      f'would you like to set custom metadata expires_at for {var} to blah: (y/n)? '
+    )
+    if answer == 'y':
+      logging.info(f'Setting...')
+      # set expires_at in their custom metadata
+      set_exp_meta(vault_client, var, jwt_string, dry_run)
+
+def set_exp_meta(vault_client, var, jwt_str, dry_run):
+  ''' extract expiration date from jwt payload and set it in vault custom metadata '''
+  exp_date_filler = 'nil'
+  exp_date_meta_key = 'expires_at'
+  payload = jwt.decode(
+    jwt_str,
+    options={"verify_signature": False, "verify_exp": False}
+  )
+  if 'exp' in payload and payload['exp'] is not None:
+    exp_payload = payload['exp']
+    logging.info(f"JWT has exp payload: {exp_payload}")
+    exp_date = datetime.datetime.utcfromtimestamp(exp_payload)
+    logging.info(f"Exp payload to date: {exp_date}")
+    exp_date_str = exp_date.isoformat("T") + "Z"
+  else:
+    logging.info(
+      f"JWT does not have exp payload or exp payload is not valid"
+    )
+    exp_date_str = exp_date_filler
+  logging.info(f"Setting custom expire_at metadata: {exp_date_str}")
+  if dry_run:
+    logging.info(
+      f"This is dry run, not going to set metdata"
+    )
+  else:
+    vault_client.update_custom_meta(var, exp_date_meta_key, exp_date_str)


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PHIRE-1395]

### Description

Add a script that sets `expires_at` meta for JWTs in Vault. Run it like so:

```
(opstools) artsy-2:opstools jxu$ foreman run --env .env.shared,.env python src/set_vault_jwt_expiration/set.py staging hokusai-sandbox
INFO:botocore.credentials:Found credentials in shared credentials file: ~/.aws/credentials
INFO:root:List of JWTs: ['TOKEN', 'TOKEN2', 'TOKEN3']
INFO:root:Checking JWT TOKEN...
INFO:root:JWT has exp payload: 1765301270
INFO:root:Exp payload to date: 2025-12-09 17:27:50
would you like to set custom metadata expires_at for TOKEN to 2025-12-09T17:27:50Z: (y/n)? y
INFO:root:Setting...
...
```

[PHIRE-1395]: https://artsyproduct.atlassian.net/browse/PHIRE-1395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ