### PR TITLE
chore: clean up review apps after 7 days

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -201,7 +201,7 @@ kind: CronJob
 metadata:
   name: opstools-cleanup-review-apps
 spec:
-  schedule: "42 9 * * 1"
+  schedule: "42 9 * * *"
   concurrencyPolicy: Forbid
   jobTemplate:
     spec:
@@ -233,7 +233,7 @@ spec:
             args:
             - python
             - src/kubernetes_cleanup_review_apps/cleanup.py
-            - "30"
+            - "7"
             - --force
             - --in_cluster
             imagePullPolicy: Always


### PR DESCRIPTION
With https://github.com/artsy/force/pull/14982, we're automating and encouraging more frequent creation of review apps. I even created 2 while demoing the capability. Currently those kubernetes namespaces and resources are destroyed after 30 days. I propose that we shorten this to 7 days. When that's not long enough, another build of the relevant branch (in projects like Force) will simply recreate the resources. (This would also require running the cron more often.)