### PR TITLE
fix: use default warn_threashold for vault-jwt scan

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -633,7 +633,6 @@ spec:
             - python
             - src/list_vault_jwt_expiration/list.py
             - production
-            - 30
             imagePullPolicy: Always
             envFrom:
             - configMapRef:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -300,7 +300,6 @@ spec:
             - python
             - src/list_vault_jwt_expiration/list.py
             - staging
-            - 30
             imagePullPolicy: Always
             envFrom:
             - configMapRef:


### PR DESCRIPTION
The type of this PR is: Fix
 
Patches #125 to just use the [default](https://github.com/artsy/opstools/blob/main/src/list_vault_jwt_expiration/list.py#L25) warn_threshold of 30 days. 
