### PR TITLE
fix: add vault_role to client instantiation for list jwt expirations

### DIFF
--- a/src/list_vault_jwt_expiration/list.py
+++ b/src/list_vault_jwt_expiration/list.py
@@ -39,8 +39,9 @@ def parse_env():
     """parse env vars"""
     vault_host = os.environ.get("VAULT_HOST")
     vault_port = os.environ.get("VAULT_PORT")
+    vault_role = os.environ.get("VAULT_ROLE")
     kvv2_mount_point = os.environ.get("VAULT_KVV2_MOUNT_POINT")
-    return vault_host, vault_port, kvv2_mount_point
+    return vault_host, vault_port, vault_role, kvv2_mount_point
 
 
 def validate(artsy_env, vault_host, vault_port):
@@ -66,11 +67,12 @@ if __name__ == "__main__":
         args.warn_threshold,
     )
     setup_logging(eval("logging." + loglevel))
-    vault_host, vault_port, kvv2_mount_point = parse_env()
-    validate(artsy_env, vault_host, vault_port)
+    vault_host, vault_port, vault_role, kvv2_mount_point = parse_env()
+    validate(artsy_env, vault_host, vault_port, kvv2_mount_point)
     validate_vault_jwt_expiration(
         vault_host,
         vault_port,
+        vault_role,
         kvv2_mount_point,
         warn_threshold,
     )

--- a/src/list_vault_jwt_expiration/list.py
+++ b/src/list_vault_jwt_expiration/list.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     )
     setup_logging(eval("logging." + loglevel))
     vault_host, vault_port, vault_role, kvv2_mount_point = parse_env()
-    validate(artsy_env, vault_host, vault_port, kvv2_mount_point)
+    validate(artsy_env, vault_host, vault_port)
     validate_vault_jwt_expiration(
         vault_host,
         vault_port,

--- a/src/list_vault_jwt_expiration/utils.py
+++ b/src/list_vault_jwt_expiration/utils.py
@@ -13,6 +13,7 @@ from lib.vault import Vault
 def validate_vault_jwt_expiration(
     vault_host,
     vault_port,
+    vault_role,
     kvv2_mount_point,
     warn_threshold,
 ):
@@ -21,6 +22,7 @@ def validate_vault_jwt_expiration(
     vault_client = Vault(
         url_host_port(vault_host, vault_port),
         auth_method="iam",
+        role=vault_role,
         kvv2_mount_point=kvv2_mount_point,
         path=vault_path,
     )
@@ -35,6 +37,7 @@ def validate_vault_jwt_expiration(
             project,
             vault_host,
             vault_port,
+            vault_role,
             kvv2_mount_point,
             warn_threshold,
             scan_results,
@@ -51,13 +54,20 @@ def validate_vault_jwt_expiration(
 
 
 def check_jwt_expiry(
-    project, vault_host, vault_port, kvv2_mount_point, warn_threshold, scan_results
+    project,
+    vault_host,
+    vault_port,
+    vault_role,
+    kvv2_mount_point,
+    warn_threshold,
+    scan_results,
 ):
     """check if JWTs for a given project will expire within a given threshold (days)"""
     vault_path = "kubernetes/apps/" + f"{project}"
     vault_client = Vault(
         url_host_port(vault_host, vault_port),
         auth_method="iam",
+        role=vault_role,
         kvv2_mount_point=kvv2_mount_point,
         path=vault_path,
     )


### PR DESCRIPTION
The type of this PR is: fix
<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PLATFORM-123]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PHIRE-1234]

### Description

<!-- Implementation description. Please be reminded to filter out sensitive information, as this is a public repository. -->

This PR patches #125 to add a `role` param when instantiating a vault client for the vault jwt expiration scan job. Currently the job is throwing a `permission denied` [error](https://my.papertrailapp.com/groups/3674473/events?q=program%3Aopstools-vault-jwt-scan&focus=1820347531369066530&selected=1820347531369066530). This makes sense considering `role` [looks to be required](https://github.com/artsy/opstools/blob/ae9946e0b375fdc507a06993357e41f847ec2e5f/src/lib/vault.py#L31) when using `iam` as a auth method. 


[PLATFORM-123]: https://artsyproduct.atlassian.net/browse/PLATFORM-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PHIRE-1234]: https://artsyproduct.atlassian.net/browse/PHIRE-1234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ