### PR TITLE
chore: upgrade tf version to 1.5.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN chown deploy:deploy /src
 RUN pip --no-cache-dir install poetry==1.8.0
 RUN pip --no-cache-dir install awscli --upgrade
 
-ARG terraform_version=1.1.9
+ARG terraform_version=1.5.7
 ARG kubectl_version=1.21.14
 
 RUN apk --no-cache --quiet add \


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PLATFORM-123]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PHIRE-1585]

### Description

<!-- Implementation description. Please be reminded to filter out sensitive information, as this is a public repository. -->

This upgrades terraform_version to 1.5.7

Related https://github.com/artsy/infrastructure/pull/787 PR


[PLATFORM-123]: https://artsyproduct.atlassian.net/browse/PLATFORM-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PHIRE-1585]: https://artsyproduct.atlassian.net/browse/PHIRE-1585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ