### PR TITLE
chore: bump terraform version to 1.10.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN chown deploy:deploy /src
 RUN pip --no-cache-dir install poetry==1.8.0
 RUN pip --no-cache-dir install awscli --upgrade
 
-ARG terraform_version=1.5.7
+ARG terraform_version=1.10.5
 ARG kubectl_version=1.21.14
 
 RUN apk --no-cache --quiet add \


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PLATFORM-123]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description. Please be reminded to filter out sensitive information, as this is a public repository. -->

This PR bump the `terraform` version in the `dockerfile` to `1.10.5`, the most recent, stable terraform version. 


[PLATFORM-123]: https://artsyproduct.atlassian.net/browse/PLATFORM-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ