### PR TITLE
feat: example of bulk-updating Claude safeguards

### DIFF
--- a/src/hokusai-app-updater/examples/claude_settings/deny_remote_commands.rb
+++ b/src/hokusai-app-updater/examples/claude_settings/deny_remote_commands.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env ruby
+require 'fileutils'
+require 'json'
+
+SETTINGS_FILENAME = ".claude/settings.json"
+DEFAULT_SETTINGS = {
+  permissions: {
+    allow: [],
+    deny: ["Read(.env)", "Read(.env.shared)"]
+  }
+}
+ADDITIONS = [
+  "Bash(hokusai:*)",
+  "Bash(aws:*)]"
+]
+
+# create settings file if it doesn't already exist
+unless File.exist?(SETTINGS_FILENAME)
+  FileUtils.mkdir_p(".claude")
+  File.open(SETTINGS_FILENAME, 'w') do |f|
+    f.write(JSON.pretty_generate(DEFAULT_SETTINGS))
+  end
+end
+
+# read in settings
+settings = JSON.parse(File.read(SETTINGS_FILENAME))
+
+# merge additions
+settings["permissions"]["deny"] |= ADDITIONS
+
+# write out updated settings
+File.open(SETTINGS_FILENAME, 'w') do |f|
+  f.write(JSON.pretty_generate(settings))
+end
+

--- a/src/hokusai-app-updater/examples/claude_settings/project_list
+++ b/src/hokusai-app-updater/examples/claude_settings/project_list
@@ -1,0 +1,2 @@
+vibrations
+horizon

--- a/src/hokusai-app-updater/update_apps.sh
+++ b/src/hokusai-app-updater/update_apps.sh
@@ -37,7 +37,7 @@ function commit() {
   BRANCH=$1
 
   echo "### confirm changes ###"
-  git diff
+  git --no-pager diff
   read -p "Enter y or Y to proceed, s or S to skip, any other input exit script: " -n 1 -r </dev/tty
   echo
   if [[ $REPLY =~ ^[Yy]$ ]]
@@ -52,7 +52,8 @@ function commit() {
   fi
 
   echo "### commit changes ###"
-  git commit -am "$MSG" --no-verify
+  git add .
+  git commit -m "$MSG" --no-verify
   echo "### push to origin ###"
   git push -f --set-upstream origin "$BRANCH" --no-verify
 


### PR DESCRIPTION
This adds an example of bulk-updating safeguards committed to projects' `.claude/settings.json` files. My motivation is to make it easy to extend these safeguards over time, even across many projects.

I ran the following commands, roughly:

```bash
# Create an isolated workspace where project can be checked out without worry about other in progress changes or branches:
mkdir ~/work/artsy/2025-08-08_claude_settings
cd ~/work/artsy/2025-08-08_claude_settings
sed 's|\(.*\)|git@github.com:artsy/\1.git|' ~/dev/artsy/opstools/src/hokusai-app-updater/examples/claude_settings/project_list | xargs -n 1 git clone

# Then switch to the bulk-updater project to begin generating PRs:
cd ~/dev/artsy/opstools/src/hokusai-app-updater
./update_apps.sh examples/claude_settings/deny_remote_commands.rb examples/claude_settings/project_list ~/work/artsy/2025-08-08_claude_settings claude "chore: deny claude access to remote commands" joeyAghion anandaroop
```

Those generated the following PRs:
* https://github.com/artsy/vibrations/pull/832
* https://github.com/artsy/horizon/pull/705

**Note** that I broke with past examples in switching to scripting in ruby. I found that was easier and ultimately less code.