### PR TITLE
fix: typo and re-run bulk updates to correct Claude settings

### DIFF
--- a/src/hokusai-app-updater/examples/claude_settings/deny_remote_commands.rb
+++ b/src/hokusai-app-updater/examples/claude_settings/deny_remote_commands.rb
@@ -11,7 +11,7 @@ DEFAULT_SETTINGS = {
 }
 ADDITIONS = [
   "Bash(hokusai:*)",
-  "Bash(aws:*)]"
+  "Bash(aws:*)"
 ]
 
 # create settings file if it doesn't already exist
@@ -24,6 +24,9 @@ end
 
 # read in settings
 settings = JSON.parse(File.read(SETTINGS_FILENAME))
+
+# remove typos (e.g.)...
+# settings["permissions"]["deny"] -= ["Bash(aws:*)]"]
 
 # merge additions
 settings["permissions"]["deny"] |= ADDITIONS


### PR DESCRIPTION
Thanks for catching the unfortunate typo. This follows up https://github.com/artsy/infrastructure/pull/983 to fix the typo and update the script with a commented-out step I added to propagate that correction to the affected repos. 