### PR TITLE
feat: upgrade terraform version to 1.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN chown deploy:deploy /src
 RUN pip --no-cache-dir install poetry==1.8.0
 RUN pip --no-cache-dir install awscli --upgrade
 
-ARG terraform_version=1.10.5
+ARG terraform_version=1.12.2
 ARG kubectl_version=1.21.14
 
 RUN apk --no-cache --quiet add \


### PR DESCRIPTION
## This repo is public.

The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PLATFORM-123]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Support https://github.com/artsy/infrastructure/pull/826/files

Currently, the terraform state drift detection script is failing due to Terraform version mismatch. The PR should fix it. 

<!-- Implementation description. Please be reminded to filter out sensitive information, as this is a public repository. -->

[PLATFORM-123]: https://artsyproduct.atlassian.net/browse/PLATFORM-123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ